### PR TITLE
nest style property when using setNativeProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,8 +217,8 @@ var drawer = React.createClass({
       mainProps = Object.assign(mainProps, propsFrag.main)
       drawerProps = Object.assign(drawerProps, propsFrag.drawer)
     }
-    this.refs.drawer.setNativeProps(drawerProps)
-    this.refs.main.setNativeProps(mainProps)
+    this.refs.drawer.setNativeProps({style: drawerProps})
+    this.refs.main.setNativeProps({style: mainProps})
   },
 
   shouldOpenDrawer (dx) {


### PR DESCRIPTION
react-native 0.13.0-rc

remove redbox warning.

```
'You are setting the style `{ right: ... }` as a prop. You should nest it in a style object. E.g. `{ style: { right: ... } }`
```
