### PR TITLE
return true if we need to update after we receive props

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,9 +98,10 @@ var drawer = React.createClass({
   ],
 
   requiresIntialize (nextProps) {
-    this.propsWhomRequireUpdate.forEach((key) => {
+    for (var i = 0; i < this.propsWhomRequireUpdate.length; i++) {
+      var key = this.propsWhomRequireUpdate[i]
       if(this.props[key] !== nextProps[key]){ return true }
-    })
+    }
   },
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
Make sure that if we need to update the drawer from a props change, we return true from `requiresInitialize`
