### PR TITLE
Fix tap gestures detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,7 +368,7 @@ var drawer = React.createClass({
 
   handlePanResponderEnd (e, gestureState) {
     // @TODO fine tune these thresholds
-    if (gestureState.moveX < 100 && (Date.now() - this._panStartTime < 500)) {
+    if (gestureState.dx < 100 && (Date.now() - this._panStartTime < 500)) {
       this._panning = false
       this.processTapGestures()
       return


### PR DESCRIPTION
I was having trouble using the `tapToClose` props, and noticed this code used to detect if the user touch is a tap gestures or a swipe gesture.

It believe there's been a mixup here between the `gestureState` attributes `moveX` and `dx`.

According to the [PanResponder documentation](https://facebook.github.io/react-native/docs/panresponder.html#content), **moveX** is _the latest screen coordinates of the recently-moved touch_, whereas **dx** is the _accumulated distance of the gesture since the touch started_

I got tapToClose to perform as I expected it to after this change.
