### PR TITLE
Add a transparent overlay on main view when opening drawer

### DIFF
--- a/index.js
+++ b/index.js
@@ -338,6 +338,7 @@ var drawer = React.createClass({
       onEnd: () => {
         this._open = true
         this._prevLeft = this._left
+        this.refs.mainOverlay.setNativeProps({ style: { height: this.state.viewport.height }})
         this.props.onOpen()
       }
     })
@@ -357,6 +358,7 @@ var drawer = React.createClass({
       onEnd: () => {
         this._open = false
         this._prevLeft = this._left
+        this.refs.mainOverlay.setNativeProps({ style: { height: 0 }})
         this.props.onClose()
       }
     })
@@ -392,8 +394,9 @@ var drawer = React.createClass({
         key="main"
         style={[this.stylesheet.main, {width: this.getMainWidth(), height: this.state.viewport.height}]}
         ref="main"
-        {...this.responder.panHandlers}>
+        {...this.responder.panHandlers}>       
         {this.props.children}
+        <View ref="mainOverlay" style={[this.stylesheet.main, {width: this.getMainWidth(), height: 0,backgroundColor:'transparent'}]} />
       </View>
     )
   },

--- a/index.js
+++ b/index.js
@@ -394,7 +394,7 @@ var drawer = React.createClass({
         key="main"
         style={[this.stylesheet.main, {width: this.getMainWidth(), height: this.state.viewport.height}]}
         ref="main"
-        {...this.responder.panHandlers}>       
+        {...this.responder.panHandlers}>
         {this.props.children}
         <View ref="mainOverlay" style={[this.stylesheet.main, {width: this.getMainWidth(), height: 0,backgroundColor:'transparent'}]} />
       </View>


### PR DESCRIPTION
There should be an overlay on main view when drawer is shown, otherwise touchables inside main view can be clicked. (The following gif displays the bug: (NEXT can be clicked))
![untitled](https://cloud.githubusercontent.com/assets/4190490/12216950/1d046940-b72d-11e5-9243-ece873c9f68b.gif)

This PR is to add a transparent overlay to fix the bug. (Following gif is fixed result)
![untitled2](https://cloud.githubusercontent.com/assets/4190490/12216967/aa8da1d2-b72d-11e5-98ea-a2c88880ed78.gif)
