### PR TITLE
Add attribute "acceptSwipe"

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This module supports a wide range of drawer styles, and hence has *a lot* of pro
 - `acceptDoubleTap` (Boolean) `false` - Toggle drawer when double tap occurs within pan mask?
 - `acceptTap` (Boolean) `false` - Toggle drawer when any tap occurs within pan mask?
 - `acceptPan` (Boolean) `true` - Allow for drawer pan (on touch drag). Set to false to effectively disable the drawer while still allowing programmatic control.
+- `acceptSwipe` (Boolean) `true` - Allow for swipe to show/hide drawer.
 - `tapToClose` (Boolean) `false` - Same as acceptTap, except only for close.
 - `negotiatePan` (Boolean) `false` - If true, attempts to handle only horizontal swipes, making it play well with a child `ScrollView`.
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ var drawer = React.createClass({
     acceptDoubleTap: React.PropTypes.bool,
     acceptTap: React.PropTypes.bool,
     acceptPan: React.PropTypes.bool,
+    acceptSwipe: React.PropTypes.bool,
     tapToClose: React.PropTypes.bool,
     styles: React.PropTypes.object,
     onOpen: React.PropTypes.func,
@@ -74,6 +75,7 @@ var drawer = React.createClass({
       acceptDoubleTap: false,
       acceptTap: false,
       acceptPan: true,
+      acceptSwipe: true,
       tapToClose: false,
       styles: {},
       onOpen: () => {},
@@ -297,7 +299,7 @@ var drawer = React.createClass({
   },
 
   handlePanResponderMove (e, gestureState) {
-    if(!this.props.acceptPan){
+    if(!this.props.acceptPan || !this.props.acceptSwipe){
       return false
     }
 
@@ -375,6 +377,8 @@ var drawer = React.createClass({
       this.processTapGestures()
       return
     }
+
+    if(!this.props.acceptSwipe) return
 
     var absRelMoveX = this.props.side === 'left'
       ? this._open ? this.state.viewport.width - gestureState.moveX : gestureState.moveX


### PR DESCRIPTION
With this param set to false, swipe will not be enabled to toggle drawer.

Sometimes, I don't want users to swipe to show drawer. I want my swipe to do other things.
