### PR TITLE
Honor Tap To Close with Negotiate Pan

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,7 +247,8 @@ var drawer = React.createClass({
   },
 
   handleStartShouldSetPanResponder (e, gestureState) {
-    if (this.props.negotiatePan) return false
+    var isListeningForTaps = this.props.acceptTap || this.props.tapToClose || this.props.acceptDoubleTap
+    if (this.props.negotiatePan && !(this._open && isListeningForTaps)) return false
     this._panStartTime = Date.now()
     if(!this.testPanResponderMask(e, gestureState)){
       return false


### PR DESCRIPTION
Might want some additional testing but this seems to honor taps within the mask properly.  Previously, if `negotiatePan={true}` the drawer would let the main content respond to taps/gestures instead of capturing them with the drawer when `captureGestures={true}`.

There's some goofy behavior if `captureGestures={true}` but none of the acceptTap/acceptDoubleTap/tapToClose are set to true with  `captureGestures={true}` so some additional work is likely needed.  But this is working for my use case.
