### PR TITLE
close drawer if stuck open with a quick flick

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,6 +371,7 @@ var drawer = React.createClass({
   handlePanResponderEnd (e, gestureState) {
     // @TODO fine tune these thresholds
     if (gestureState.dx < 100 && (Date.now() - this._panStartTime < 500)) {
+      if (!this._open) this.close()
       this._panning = false
       this.processTapGestures()
       return


### PR DESCRIPTION
fixes: https://github.com/root-two/react-native-drawer/issues/75
