### PR TITLE
Add device orientation support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,21 @@ var React = require('react-native')
 var { PanResponder, View, StyleSheet, Dimensions, PropTypes } = React
 var deviceScreen = Dimensions.get('window')
 var tween = require('./Tweener')
+var Orientation = require('react-native-orientation')
+
+Orientation.getOrientation((err,orientation)=> {
+  console.log("Current Device Orientation: ", orientation);
+  if(orientation == 'LANDSCAPE') {
+    deviceScreen = flipDevice(deviceScreen);
+  }
+});
+
+function flipDevice(deviceScreen) {
+  var temp = deviceScreen.width;
+  deviceScreen.width = deviceScreen.height;
+  deviceScreen.height = temp;
+  return deviceScreen;
+}
 
 var drawer = React.createClass({
 
@@ -193,6 +208,18 @@ var drawer = React.createClass({
 
   componentWillMount () {
     this.initialize(this.props)
+  },
+
+  componentDidMount () {
+    Orientation.addOrientationListener(this._orientationDidChange);
+  },
+
+  componentWillUnmount () {
+    Orientation.removeOrientationListener(this._orientationDidChange);
+  },
+
+  _orientationDidChange (orientation) {
+    deviceScreen = flipDevice(deviceScreen);
   },
 
   componentDidUpdate () {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "git@github.com:rt2zz/react-native-drawer.git"
   },
   "dependencies": {
-    "tween-functions": "^1.0.1"
+    "tween-functions": "^1.0.1",
+    "react-native-orientation": "^1.13.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
This update uses react-native-orientation to detect device orientation and update the deviceScreen variable. If this variable is not updated on orientation changes, the panOpenMask and panCloseMask are not updated correctly and result in an area of the screen being un-clickable after rotating from portrait to landscape.

The downside of this approach is that it adds a dependency on react-native-orientation. Installing said package requires adding a folder to XCode, etc., it's not just an npm update.
