### PR TITLE
ESLint and ESLint-Plugin-React rules together with ES6.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+# node_modules ignored by default
+android/**
+ios/**
+node_modules/**

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,223 @@
+
+/***************************************************************************************
+*
+*  The file contains rules which are thought that they would be used in the project.
+*
+*  http://eslint.org/docs/rules/
+*
+***************************************************************************************/
+
+{
+
+	"parser": "babel-eslint",
+
+	"env": {
+		"es6": true,
+		"browser": true,
+	},
+
+	"ecmaFeatures": {
+		"arrowFunctions": true,
+		"binaryLiterals": true,
+		"blockBindings": true,
+		"classes": true,
+		"defaultParams": true,
+		"destructuring": true,
+		"modules": true,
+		"objectLiteralComputedProperties": true,
+		"objectLiteralDuplicateProperties": true,
+		"objectLiteralShorthandMethods": true,
+		"objectLiteralShorthandProperties": true,
+		"restParams": true,         // Indicated by three dots (...). That named parameter becomes an Array containing the rest of the parameters passed to the function.
+		"superInFunctions": true,
+		"templateStrings": true,    // Used inside of `` type quotes.
+		"jsx": true,
+	},
+
+	"plugins": ["react", "react-native"],
+
+	// Map from global var to bool specifying if it can be redefined
+	"globals": {
+		"__dirname": false,
+		"cancelAnimationFrame": false,
+		"clearImmediate": true,
+		"clearInterval": false,
+		"clearTimeout": false,
+		"console": false,
+		"document": false,
+		"escape": false,
+		"exports": false,
+		"fetch": false,
+		"global": false,
+		"jest": false,
+		"Map": true,
+		"module": false,
+		"navigator": false,
+		"process": false,
+		"Promise": true,
+		"requestAnimationFrame": true,
+		"require": false,
+		"Set": true,
+		"setImmediate": true,
+		"setInterval": false,
+		"setTimeout": false,
+		"window": false,
+		"XMLHttpRequest": false,
+		"pit": false
+	},
+
+	"rules": {
+
+		/* Possible Errors */
+		"comma-dangle": 0,
+		"no-console": 1,
+		"no-debugger": 1,
+		"no-dupe-keys": 2,
+		"no-dupe-args": 2,
+		"no-ex-assign": 2,
+		"no-extra-boolean-cast": 1,
+		"no-extra-parens": 0,
+		"no-extra-semi": 1,
+		"no-invalid-regexp": 1,
+		"no-negated-in-lhs": 1,
+		"no-obj-calls": 1,
+		"no-regex-spaces": 1,
+		"no-reserved-keys": 0,
+		"no-sparse-arrays": 1,
+		"no-unreachable": 1,
+		"use-isnan": 1,
+		"valid-jsdoc": 0,
+		"valid-typeof": 1,
+
+		/* Best Practices */
+		"accessor-pairs": [1, {"getWithoutSet": true}],	// Enforces getter/setter pairs in objects
+		"block-scoped-var": 0,           // treat var statements as if they were block scoped (off by default)
+		"complexity": 0,                 // specify the maximum cyclomatic complexity allowed in a program (off by default)
+		"consistent-return": 0,          // require return statements to either always or never specify values
+		"curly": 1,                      // specify curly brace conventions for all control statements
+		"default-case": 0,               // require default case in switch statements (off by default)
+		"dot-location": [1, "property"], // enforces consistent newlines before or after dots
+		"dot-notation": 1,               // encourages use of dot notation whenever possible
+		"eqeqeq": [1, "smart"],          // require the use of === and !==
+		"guard-for-in": 0,               // make sure for-in loops have an if statement (off by default)
+		"no-alert": 1,                   // disallow the use of alert, confirm and prompt
+		"no-caller": 1,                  // disallow use of arguments.caller or arguments.callee
+		"no-case-declarations": 1,       // disallow lexical declarations in case clauses
+		"no-div-regex": 1,               // disallow division operators explicitly at beginning of regular expression (off by default)
+		"no-else-return": 0,             // disallow else after a return in an if (off by default)
+		"no-empty-label": 1,             // disallow use of labels for anything other then loops and switches
+		"no-eq-null": 0,                 // disallow comparisons to null without a type-checking operator (off by default)
+		"no-eval": 1,                    // disallow use of eval()
+		"no-extend-native": 1,           // disallow adding to native types
+		"no-extra-bind": 1,              // disallow unnecessary function binding
+		"no-fallthrough": 1,             // disallow fallthrough of case statements
+		"no-floating-decimal": 1,        // disallow the use of leading or trailing decimal points in numeric literals (off by default)
+		"no-implicit-coercion": 1,       // disallow the type conversions with shorter notations
+		"no-implied-eval": 1,            // disallow use of eval()-like methods
+		"no-invalid-this": 1,            // disallow this keywords outside of classes or class-like objects
+		"no-iterator": 1,                // disallow usage of __iterator__ property
+		"no-labels": 1,                  // disallow use of labeled statements
+		"no-lone-blocks": 1,             // disallow unnecessary nested blocks
+		"no-loop-func": 0,               // disallow creation of functions within loops
+		"no-magic-numbers": 1,           // disallow the use of magic numbers
+		"no-multi-spaces": 1,            // disallow use of multiple spaces (fixable)
+		"no-multi-str": 0,               // disallow use of multiline strings
+		"no-native-reassign": 0,         // disallow reassignments of native objects
+		"no-new-func": 1,                // disallow use of new operator for Function object
+		"no-new-wrappers": 1,            // disallows creating new instances of String,Number, and Boolean
+		"no-new": 1,                     // disallow use of new operator when not part of the assignment or comparison
+		"no-octal-escape": 1,            // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+		"no-octal": 1,                   // disallow use of octal literals
+		"no-param-reassign": 1,          // disallow reassignment of function parameters
+		"no-process-env": 0,             // disallow use of process.env in Node.js
+		"no-proto": 1,                   // disallow usage of __proto__ property
+		"no-redeclare": 0,               // disallow declaring the same variable more then once
+		"no-return-assign": 1,           // disallow use of assignment in return statement
+		"no-script-url": 1,              // disallow use of javascript: urls.
+		"no-self-compare": 1,            // disallow comparisons where both sides are exactly the same (off by default)
+		"no-sequences": 1,               // disallow use of comma operator
+		"no-throw-literal": 1,           // restrict what can be thrown as an exception
+		"no-unused-expressions": 0,      // disallow usage of expressions in statement position
+		"no-useless-call": 1,            // disallow unnecessary .call() and .apply()
+		"no-useless-concat": 1,          // disallow unnecessary concatenation of literals or template literals
+		"no-void": 1,                    // disallow use of void operator (off by default)
+		"no-warning-comments": 0,        // disallow usage of configurable warning terms in comments: 1,  // e.g. TODO or FIXME (off by default)
+		"no-with": 1,                    // disallow use of the with statement
+		"radix": 1,                      // require use of the second argument for parseInt() (off by default)
+		"vars-on-top": 0,                // requires to declare all vars on top of their containing scope (off by default)
+		"wrap-iife": 0,                  // require immediate function invocation to be wrapped in parentheses (off by default)
+		"yoda": 1,                       // require or disallow Yoda conditions
+
+		/* Strict Mode */
+		"strict": [2, "global"],
+
+		/* Variables */
+		"no-undef": 2,
+		"no-undef-init": 1,
+		"no-unused-vars": [1, {"vars": "all", "args": "none"}], // disallow declaration of variables that are not used in the code
+		"no-shadow-restricted-names": 1,
+
+		/* Stylistic Issues */
+		"camelcase": [1, {"properties": "never"}],
+		"eol-last": 1,
+		"indent": [1, "tab"],
+		"quotes": [1, "single", "avoid-escape"],
+		"linebreak-style": [1, "unix"],
+		"new-parens": 1,
+		"no-trailing-spaces": 1,
+		"semi": [1, "always"],
+		"semi-spacing": 1,	             // require a space after a semi-colon
+		"space-after-keywords": 1,
+		"space-infix-ops": 1,
+		"space-return-throw-case": 1,
+
+		/* ECMAScript 6 */
+		"no-class-assign": 2,
+		"object-shorthand": 0,
+
+		/* React Issues */
+		"react/display-name": [1, { "acceptTranspilerName": true }],          // Prevent missing displayName in a React component definition
+		"react/forbid-prop-types": 1,     // Forbid certain propTypes
+		"react/jsx-boolean-value": 1,     // Enforce boolean attributes notation in JSX (fixable)
+		"react/jsx-closing-bracket-location": 1,  // Validate closing bracket location in JSX
+		"react/jsx-curly-spacing": 1,     // Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
+		"react/jsx-equals-spacing": 1,    // Enforce or disallow spaces around equal signs in JSX attributes
+		"react/jsx-handler-names": 1,     // Enforce event handler naming conventions in JSX
+		"react/jsx-indent-props": [1, "tab"],  // Validate props indentation in JSX
+		"react/jsx-indent": [1, "tab"],   // Validate JSX indentation
+		"react/jsx-key": 1,               // Validate JSX has key prop when in array or iterator
+		"react/jsx-max-props-per-line": 1,  // Limit maximum of props on a single line in JSX
+		"react/jsx-no-bind": [1, { "ignoreRefs": false, "allowArrowFunctions": true, "allowBind": true }],  // Prevent usage of .bind() and arrow functions in JSX props
+		"react/jsx-no-duplicate-props": 1,  // Prevent duplicate props in JSX
+		"react/jsx-no-literals": 1,       // Prevent usage of unwrapped JSX strings
+		"react/jsx-no-undef": 1,          // Disallow undeclared variables in JSX
+		"react/jsx-pascal-case": 1,       // Enforce PascalCase for user-defined JSX components
+		"react/jsx-quotes": 0,            // DEPRECATED - Enforce quote style for JSX attributes
+		"react/jsx-sort-prop-types": 1,   // Enforce propTypes declarations alphabetical sorting
+		"react/jsx-sort-props": 1,        // Enforce props alphabetical sorting
+		"react/jsx-uses-react": 1,        // Prevent React to be incorrectly marked as unused
+		"react/jsx-uses-vars": 1,         // Prevent variables used in JSX to be incorrectly marked as unused
+		"react/no-danger": 1,             // Prevent usage of dangerous JSX properties
+		"react/no-deprecated": 1,         // Prevent usage of deprecated methods
+		"react/no-did-mount-set-state": [1, "allow-in-func"],   // Prevent usage of setState in componentDidMount
+		"react/no-did-update-set-state": [1, "allow-in-func"],  // Prevent usage of setState in componentDidUpdate
+		"react/no-direct-mutation-state": 1,                    // Prevent direct mutation of this.state
+		"react/no-is-mounted": 1,         // Prevent usage of isMounted
+		"react/no-multi-comp": 1,         // Prevent multiple component definition per file
+		"react/no-set-state": 1,          // Prevent usage of setState
+		"react/no-string-refs": 1,        // Prevent using string references in ref attribute.
+		"react/no-unknown-property": 1,   // Prevent usage of unknown DOM property (fixable)
+		"react/prefer-es6-class": 1,      // Enforce ES5 or ES6 class for React Components
+		"react/prop-types": 1,            // Prevent missing props validation in a React component definition
+		"react/react-in-jsx-scope": 1,    // Prevent missing React when using JSX
+		"react/require-extension": 1,     // Restrict file extensions that may be required
+		"react/self-closing-comp": 1,     // Prevent extra closing tags for components without children
+		"react/sort-comp": 1,             // Enforce component methods order
+		"react/wrap-multilines": [1, {"declaration": false, "assignment": false, "return": true}],  // Prevent missing parentheses around multilines JSX (fixable)
+
+		/* React-Native Issues */
+		"react-native/no-unused-styles": 1,           // Detect StyleSheet rules which are not used in your React components
+		"react-native/split-platform-components": 1,  // Enforce using platform specific filenames when necessary
+	}
+
+}

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ var Drawer = require('react-native-drawer')
 
 var Application = React.createClass({
   closeControlPanel: function(){
-    this.refs.drawer.close()
+    this.drawer.close()
   },
   openControlPanel: function(){
-    this.refs.drawer.open()
+    this.drawer.open()
   },
   render: function() {
     return (
@@ -146,7 +146,7 @@ Will result in a skewed fade out animation.
 Two options:
 1. Using the Drawer Ref:
 ```js
-onPress={() => {this.refs.drawer.open()}}
+onPress={() => {this.drawer.open()}}
 ```
 2. Using Context
 ```js

--- a/Tweener.js
+++ b/Tweener.js
@@ -1,37 +1,37 @@
 var easingTypes = require('tween-functions');
 
 module.exports = function(config) {
-  return new Tween(config)
-}
+	return new Tween(config);
+};
 
 function Tween(config){
-  this._rafLoop = this._rafLoop.bind(this)
-  this.terminate = this.terminate.bind(this)
+	this._rafLoop = this._rafLoop.bind(this);
+	this.terminate = this.terminate.bind(this);
 
-  this._t0 = Date.now()
-  this._config = config
-  this._rafLoop()
+	this._t0 = Date.now();
+	this._config = config;
+	this._rafLoop();
 }
 
 Tween.prototype._rafLoop = function() {
-  if(this._break){ return }
+	if (this._break){ return; }
 
-  var {duration, start, end, easingType} = this._config
-  var now = Date.now()
-  var elapsed = now - this._t0
+	var {duration, start, end, easingType} = this._config;
+	var now = Date.now();
+	var elapsed = now - this._t0;
 
-  if(elapsed >= duration){
-    this._config.onFrame(end)
-    this._config.onEnd()
-    return
-  }
+	if (elapsed >= duration){
+		this._config.onFrame(end);
+		this._config.onEnd();
+		return;
+	}
 
-  var tweenVal = easingTypes[easingType](elapsed, start, end, duration)
-  this._config.onFrame(tweenVal)
+	var tweenVal = easingTypes[easingType](elapsed, start, end, duration);
+	this._config.onFrame(tweenVal);
 
-  requestAnimationFrame(this._rafLoop)
-}
+	requestAnimationFrame(this._rafLoop);
+};
 
 Tween.prototype.terminate = function(){
-  this._break = true
-}
+	this._break = true;
+};

--- a/examples/RNDrawerDemo/MyMainView.js
+++ b/examples/RNDrawerDemo/MyMainView.js
@@ -1,13 +1,17 @@
 var React = require('react-native')
+var SliderJS = require('react-native-slider')
 
 var {
-  SwitchIOS,
+  Switch,
   SliderIOS,
   PickerIOS,
   PickerItemIOS,
   View,
   ScrollView,
   Text,
+	Platform,
+	StyleSheet,
+	Platform,
 } = React
 
 var styles = require('./styles')
@@ -46,7 +50,7 @@ module.exports = React.createClass({
           <Text style={styles.categoryLabel}>Drawer Type</Text>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Overlay</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {drawerType:'overlay'})}
               style={styles.rowInput}
               disabled={this.props.drawerType === 'overlay'}
@@ -54,7 +58,7 @@ module.exports = React.createClass({
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Displace</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {drawerType:'displace'})}
               style={styles.rowInput}
               disabled={this.props.drawerType === 'displace'}
@@ -62,7 +66,7 @@ module.exports = React.createClass({
           </View>
           <View style={styles.lastRow}>
             <Text style={styles.rowLabel}>Static</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {drawerType:'static'})}
               style={styles.rowInput}
               disabled={this.props.drawerType === 'static'}
@@ -73,43 +77,48 @@ module.exports = React.createClass({
           <Text style={styles.categoryLabel}>Trigger Options</Text>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>relativeDrag</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={ (value) => { this.setParentState({'relativeDrag': value})} }
               style={styles.rowInput}
               value={this.props.relativeDrag} />
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>panStartCompensation</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={ (value) => { this.setParentState({'panStartCompensation': value})} }
               style={styles.rowInput}
               value={this.props.panStartCompensation} />
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>disabled</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={ (value) => { this.setParentState({'disabled': value})} }
               style={styles.rowInput}
               value={this.props.disabled} />
           </View>
-          <View style={styles.row}>
-            <Text style={styles.rowLabel}>openDrawerThreshold</Text>
-            <SliderIOS
-              style={styles.slider}
-              maximumValue={1}
-              value={this.props.openDrawerThreshold}
-              onSlidingComplete={(value) => {
-                  this.setParentState({openDrawerThreshold: value})
-                }}
-                />
-              <Text style={styles.sliderMetric}>{Math.round(this.props.openDrawerThreshold*100)}%</Text>
+	        <View style={styles.row}>
+						<Text style={styles.rowLabel}>openDrawerThreshold</Text>
+						<SliderJS
+								style={styles.slider}
+								trackStyle={sliderStyles.track}
+		            thumbStyle={sliderStyles.thumb}
+		            minimumTrackTintColor={minimumTrackTintColor}
+		            maximumTrackTintColor={maximumTrackTintColor}
+								thumbTintColor={thumbTintColor}
+	              maximumValue={.5}
+	              value={this.props.closedDrawerOffset}
+	              onSlidingComplete={(value) => {
+	                  this.setParentState({openDrawerThreshold: value})
+	                }}
+							/>
+            <Text style={styles.sliderMetric}>{Math.round(this.props.openDrawerThreshold*100)}%</Text>
           </View>
 
           {/*tween presets*/}
           <Text style={styles.categoryLabel}>Example Tweens</Text>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>None</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {tweenHandlerPreset:null})}
               style={styles.rowInput}
               disabled={this.props.tweenHandlerPreset === null}
@@ -117,7 +126,7 @@ module.exports = React.createClass({
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Material Design</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {tweenHandlerPreset:'material'})}
               style={styles.rowInput}
               disabled={this.props.tweenHandlerPreset === 'material'}
@@ -125,7 +134,7 @@ module.exports = React.createClass({
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Rotate</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {tweenHandlerPreset:'rotate'})}
               style={styles.rowInput}
               disabled={this.props.tweenHandlerPreset === 'rotate'}
@@ -133,7 +142,7 @@ module.exports = React.createClass({
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Parallax</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {tweenHandlerPreset:'parallax'})}
               style={styles.rowInput}
               disabled={this.props.tweenHandlerPreset === 'parallax'}
@@ -144,7 +153,7 @@ module.exports = React.createClass({
           <Text style={styles.categoryLabel}>tweenEasing</Text>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>linear</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {tweenEasing:'linear'})}
               style={styles.rowInput}
               disabled={this.props.tweenEasing === 'linear'}
@@ -152,7 +161,7 @@ module.exports = React.createClass({
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>easeOutQuad</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {tweenEasing:'easeOutQuad'})}
               style={styles.rowInput}
               disabled={this.props.tweenEasing === 'easeOutQuad'}
@@ -160,7 +169,7 @@ module.exports = React.createClass({
           </View>
           <View style={styles.lastRow}>
             <Text style={styles.rowLabel}>easeOutElastic</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={this.setParentState.bind(this, {tweenEasing:'easeOutElastic'})}
               style={styles.rowInput}
               disabled={this.props.tweenEasing === 'easeOutElastic'}
@@ -171,8 +180,13 @@ module.exports = React.createClass({
           <Text style={styles.categoryLabel}>Offsets</Text>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>openDrawerOffset</Text>
-            <SliderIOS
+            <SliderJS
               style={styles.slider}
+							trackStyle={sliderStyles.track}
+							thumbStyle={sliderStyles.thumb}
+							minimumTrackTintColor={minimumTrackTintColor}
+							maximumTrackTintColor={maximumTrackTintColor}
+							thumbTintColor={thumbTintColor}
               maximumValue={.5}
               value={this.props.openDrawerOffset}
               onSlidingComplete={(value) => {
@@ -183,8 +197,13 @@ module.exports = React.createClass({
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>closedDrawerOffset</Text>
-            <SliderIOS
+            <SliderJS
               style={styles.slider}
+							trackStyle={sliderStyles.track}
+							thumbStyle={sliderStyles.thumb}
+							minimumTrackTintColor={minimumTrackTintColor}
+							maximumTrackTintColor={maximumTrackTintColor}
+							thumbTintColor={thumbTintColor}
               maximumValue={.5}
               value={this.props.closedDrawerOffset}
               onSlidingComplete={(value) => {
@@ -198,8 +217,13 @@ module.exports = React.createClass({
           <Text style={styles.categoryLabel}>Pan Mask</Text>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>panOpenMask</Text>
-            <SliderIOS
+            <SliderJS
               style={styles.slider}
+							trackStyle={sliderStyles.track}
+							thumbStyle={sliderStyles.thumb}
+							minimumTrackTintColor={minimumTrackTintColor}
+							maximumTrackTintColor={maximumTrackTintColor}
+							thumbTintColor={thumbTintColor}
               maximumValue={1}
               value={this.props.panOpenMask}
               onSlidingComplete={(value) => {
@@ -210,8 +234,13 @@ module.exports = React.createClass({
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>panCloseMask</Text>
-            <SliderIOS
+            <SliderJS
               style={styles.slider}
+							trackStyle={sliderStyles.track}
+							thumbStyle={sliderStyles.thumb}
+							minimumTrackTintColor={minimumTrackTintColor}
+							maximumTrackTintColor={maximumTrackTintColor}
+							thumbTintColor={thumbTintColor}
               maximumValue={1}
               value={this.props.panCloseMask}
               onSlidingComplete={(value) => {
@@ -225,28 +254,28 @@ module.exports = React.createClass({
           <Text style={styles.categoryLabel}>Others</Text>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Accept Tap</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={ (value) => { this.setParentState({'acceptTap': value})} }
               style={styles.rowInput}
               value={this.props.acceptTap} />
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Accept Double Tap</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={ (value) => { this.setParentState({'acceptDoubleTap': value})} }
               style={styles.rowInput}
               value={this.props.acceptDoubleTap} />
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Accept Pan</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={ (value) => { this.setParentState({'acceptPan': value})} }
               style={styles.rowInput}
               value={this.props.acceptPan} />
           </View>
           <View style={styles.row}>
             <Text style={styles.rowLabel}>Right Side (not hot changeable)</Text>
-            <SwitchIOS
+            <Switch
               onValueChange={ (value) => { this.setParentState({'rightSide': value})} }
               style={styles.rowInput}
               disabled={true}
@@ -257,3 +286,71 @@ module.exports = React.createClass({
     )
   }
 })
+
+
+
+// Shadow props are not supported in React-Native Android apps.
+// The below part handles this issue.
+
+// iOS Styles
+var iosStyles = StyleSheet.create({
+  track: {
+    height: 2,
+    borderRadius: 1,
+  },
+  thumb: {
+    width: 30,
+    height: 30,
+    borderRadius: 30 / 2,
+    backgroundColor: 'white',
+    shadowColor: 'black',
+    shadowOffset: {width: 3, height: 5},
+    shadowRadius: 5,
+    shadowOpacity: 0.75,
+  }
+});
+
+var iosMinTrTintColor = '#1073ff';
+var iosMaxTrTintColor = '#b7b7b7';
+var iosThumbTintColor = '#343434';
+
+// Android styles
+var androidStyles = StyleSheet.create({
+  container: {
+    height: 40,
+    justifyContent: 'center',
+  },
+  track: {
+    height: 4,
+    borderRadius: 4 / 2,
+  },
+  thumb: {
+    position: 'absolute',
+    width: 20,
+    height: 20,
+    borderRadius: 20 / 2,
+  },
+  touchArea: {
+    position: 'absolute',
+    backgroundColor: 'transparent',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  debugThumbTouchArea: {
+    position: 'absolute',
+    backgroundColor: 'green',
+    opacity: 0.5,
+  }
+});
+
+var androidMinTrTintColor = '#26A69A';
+var androidMaxTrTintColor = '#d3d3d3';
+var androidThumbTintColor = '#009688';
+
+
+var sliderStyles = (Platform.OS === 'ios') ? iosStyles : androidStyles;
+var minimumTrackTintColor = (Platform.OS === 'ios') ? iosMinTrTintColor : androidMinTrTintColor;
+var maximumTrackTintColor = (Platform.OS === 'ios') ? iosMaxTrTintColor : androidMaxTrTintColor;
+var thumbTintColor = (Platform.OS === 'ios') ? iosThumbTintColor : androidThumbTintColor;

--- a/examples/RNDrawerDemo/index.android.js
+++ b/examples/RNDrawerDemo/index.android.js
@@ -1,0 +1,131 @@
+/**
+ * Sample React Native App
+ * https://github.com/facebook/react-native
+ */
+ var React = require('react-native');
+ var {
+   AppRegistry,
+   Text,
+   View,
+ } = React;
+
+ var styles = require('./styles')
+ var drawerStyles = {
+   drawer: {
+     shadowColor: "#000000",
+     shadowOpacity: 0.8,
+     shadowRadius: 0,
+   }
+ }
+
+ var Drawer = require('react-native-drawer')
+ var MyMainView = require('./MyMainView')
+ var MyControlPanel = require('./ControlPanel')
+
+ var deviceScreen = require('Dimensions').get('window')
+ var tweens = require('./tweens')
+
+ var counter = 0
+ var RNDrawer = React.createClass({
+   getInitialState(){
+     return {
+       drawerType: 'overlay',
+       openDrawerOffset:100,
+       closedDrawerOffset:0,
+       panOpenMask: .1,
+       panCloseMask: .9,
+       relativeDrag: false,
+       panStartCompensation: true,
+       openDrawerThreshold: .25,
+       tweenHandlerOn: false,
+       tweenDuration: 350,
+       tweenEasing: 'linear',
+       disabled: false,
+       tweenHandlerPreset: null,
+       acceptDoubleTap: true,
+       acceptTap: false,
+       acceptPan: true,
+       rightSide: false,
+     }
+   },
+
+   setDrawerType(type){
+     this.setState({
+       drawerType: type
+     })
+   },
+
+   tweenHandler(ratio){
+     if(!this.state.tweenHandlerPreset){ return {} }
+     return tweens[this.state.tweenHandlerPreset](ratio)
+   },
+
+   noopChange(){
+     this.setState({
+       changeVal: Math.random()
+     })
+   },
+
+   openDrawer(){
+     this.drawer.open()
+   },
+
+   setStateFrag(frag){
+     this.setState(frag)
+   },
+
+   render() {
+     var controlPanel = <MyControlPanel closeDrawer={() => {this.drawer.close()}} />
+     return (
+       <Drawer
+         ref={c => this.drawer = c}
+         type={this.state.drawerType}
+         animation={this.state.animation}
+         openDrawerOffset={this.state.openDrawerOffset}
+         closedDrawerOffset={this.state.closedDrawerOffset}
+         panOpenMask={this.state.panOpenMask}
+         panCloseMask={this.state.panCloseMask}
+         relativeDrag={this.state.relativeDrag}
+         panStartCompensation={this.state.panStartCompensation}
+         openDrawerThreshold={this.state.openDrawerThreshold}
+         content={controlPanel}
+         styles={drawerStyles}
+         disabled={this.state.disabled}
+         tweenHandler={this.tweenHandler}
+         tweenDuration={this.state.tweenDuration}
+         tweenEasing={this.state.tweenEasing}
+         acceptDoubleTap={this.state.acceptDoubleTap}
+         acceptTap={this.state.acceptTap}
+         acceptPan={this.state.acceptPan}
+         changeVal={this.state.changeVal}
+         negotiatePan={false}
+         side={this.state.rightSide ? 'right' : 'left'}
+         >
+         <MyMainView
+           drawerType={this.state.drawerType}
+           setParentState={this.setStateFrag}
+           openDrawer={this.openDrawer}
+           openDrawerOffset={this.state.openDrawerOffset}
+           closedDrawerOffset={this.state.closedDrawerOffset}
+           panOpenMask={this.state.panOpenMask}
+           panCloseMask={this.state.panCloseMask}
+           relativeDrag= {this.state.relativeDrag}
+           panStartCompensation= {this.state.panStartCompensation}
+           tweenHandlerOn={this.state.tweenHandlerOn}
+           disabled={this.state.disabled}
+           openDrawerThreshold={this.state.openDrawerThreshold}
+           tweenEasing={this.state.tweenEasing}
+           tweenHandlerPreset={this.state.tweenHandlerPreset}
+           animation={this.state.animation}
+           noopChange={this.noopChange}
+           acceptTap={this.state.acceptTap}
+           acceptDoubleTap={this.state.acceptDoubleTap}
+           acceptPan={this.state.acceptPan}
+           rightSide={this.state.rightSide}
+           />
+       </Drawer>
+     );
+   }
+ });
+
+ AppRegistry.registerComponent('RNDrawer', () => RNDrawer);

--- a/examples/RNDrawerDemo/index.ios.js
+++ b/examples/RNDrawerDemo/index.ios.js
@@ -67,7 +67,7 @@ var RNDrawerDemo = React.createClass({
   },
 
   openDrawer(){
-    this.refs.drawer.open()
+    this.drawer.open()
   },
 
   setStateFrag(frag){
@@ -75,10 +75,10 @@ var RNDrawerDemo = React.createClass({
   },
 
   render() {
-    var controlPanel = <MyControlPanel closeDrawer={() => {this.refs.drawer.close()}} />
+    var controlPanel = <MyControlPanel closeDrawer={() => {this.drawer.close()}} />
     return (
       <Drawer
-        ref="drawer"
+        ref={c => this.drawer = c}
         type={this.state.drawerType}
         animation={this.state.animation}
         openDrawerOffset={this.state.openDrawerOffset}

--- a/examples/RNDrawerDemo/package.json
+++ b/examples/RNDrawerDemo/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "react-native-drawer": "latest",
-    "react-native": "^0.13.0"
+    "react-native": "^0.13.0",
+    "react-native-slider": "^0.4.0"
   }
 }

--- a/examples/RNDrawerDemo/styles.js
+++ b/examples/RNDrawerDemo/styles.js
@@ -72,7 +72,7 @@ module.exports = StyleSheet.create({
   },
   slider: {
     width: 150,
-    height: 10,
+    height: 30,
     margin: 10,
   },
   picker: {

--- a/index.js
+++ b/index.js
@@ -1,447 +1,522 @@
-var React = require('react-native')
-var { PanResponder, View, StyleSheet, Dimensions, PropTypes } = React
-var deviceScreen = Dimensions.get('window')
-var tween = require('./Tweener')
+var React = require('react-native');
+var { PanResponder, View, StyleSheet, Dimensions, PropTypes, Component } = React;
+var deviceScreen = Dimensions.get('window');
+var tween = require('./Tweener');
 
-var drawer = React.createClass({
+class Drawer extends Component {
 
-  _left: 0,
-  _prevLeft: 0,
-  _offsetOpen: 0,
-  _offsetClosed: 0,
-  _open: false,
-  _panning: false,
-  _tweenPending: false,
-  _lastPress: 0,
-  _panStartTime: 0,
-  _syncAfterUpdate: false,
+	constructor(props) {
 
-  statics: {
-    tweenPresets: {
-      parallax: (ratio, side = 'left') => {
-        var drawer = {}
-        drawer[side] = -150*(1-ratio)
-        return { drawer: drawer }
-      }
-    }
-  },
+		super(props);
 
-  propTypes: {
-    type: React.PropTypes.string,
-    closedDrawerOffset: React.PropTypes.number,
-    openDrawerOffset: React.PropTypes.number,
-    openDrawerThreshold: React.PropTypes.number,
-    relativeDrag: React.PropTypes.bool,
-    panStartCompensation: React.PropTypes.bool,
-    panOpenMask: React.PropTypes.number,
-    panCloseMask: React.PropTypes.number,
-    captureGestures: React.PropTypes.bool,
-    negotiatePan: React.PropTypes.bool,
-    initializeOpen: React.PropTypes.bool,
-    tweenHandler: React.PropTypes.func,
-    tweenDuration: React.PropTypes.number,
-    tweenEasing: React.PropTypes.string,
-    disabled: React.PropTypes.bool,
-    acceptDoubleTap: React.PropTypes.bool,
-    acceptTap: React.PropTypes.bool,
-    acceptPan: React.PropTypes.bool,
-    tapToClose: React.PropTypes.bool,
-    styles: React.PropTypes.object,
-    onOpen: React.PropTypes.func,
-    onOpenStart: React.PropTypes.func,
-    onClose: React.PropTypes.func,
-    onCloseStart: React.PropTypes.func,
-    side: React.PropTypes.oneOf(['left', 'right']),
-  },
+		// Manuel `this` keyword binding - No Autobinding in ES6 Classes
+		this.handleStartShouldSetPanResponderCapture = this.handleStartShouldSetPanResponderCapture.bind(this);
+		this.handleStartShouldSetPanResponder = this.handleStartShouldSetPanResponder.bind(this);
+		this.handleMoveShouldSetPanResponderCapture = this.handleMoveShouldSetPanResponderCapture.bind(this);
+		this.handleMoveShouldSetPanResponder = this.handleMoveShouldSetPanResponder.bind(this);
+		this.handlePanResponderMove = this.handlePanResponderMove.bind(this);
+		this.handlePanResponderEnd = this.handlePanResponderEnd.bind(this);
+		this.componentWillMount = this.componentWillMount.bind(this);
+		this.componentWillReceiveProps = this.componentWillReceiveProps.bind(this);
+		this.componentDidUpdate = this.componentDidUpdate.bind(this);
+		this.updatePosition = this.updatePosition.bind(this);
+		this.shouldOpenDrawer = this.shouldOpenDrawer.bind(this);
+		this.processTapGestures = this.processTapGestures.bind(this);
+		this.testPanResponderMask = this.testPanResponderMask.bind(this);
+		this.open = this.open.bind(this);
+		this.close = this.close.bind(this);
+		this.toggle = this.toggle.bind(this);
+		this.getMainView = this.getMainView.bind(this);
+		this.getDrawerView = this.getDrawerView.bind(this);
+		this.getOpenLeft = this.getOpenLeft.bind(this);
+		this.getClosedLeft = this.getClosedLeft.bind(this);
+		this.getMainWidth = this.getMainWidth.bind(this);
+		this.getDrawerWidth = this.getDrawerWidth.bind(this);
+		this.initialize = this.initialize.bind(this);
+		this.handleSetViewport = this.handleSetViewport.bind(this);
+		this.resync = this.resync.bind(this);
+		this.requiresResync = this.requiresResync.bind(this);
 
-  getDefaultProps () {
-    return {
-      type: 'displace',
-      closedDrawerOffset: 0,
-      openDrawerOffset: 0,
-      openDrawerThreshold: .25,
-      relativeDrag: true,
-      panStartCompensation: true,
-      panOpenMask: .25,
-      panCloseMask: .25,
-      captureGestures: false,
-      negotiatePan: false,
-      initializeOpen: false,
-      tweenHandler: null,
-      tweenDuration: 250,
-      tweenEasing: 'linear',
-      disabled: false,
-      acceptDoubleTap: false,
-      acceptTap: false,
-      acceptPan: true,
-      tapToClose: false,
-      styles: {},
-      onOpen: () => {},
-      onClose: () => {},
-      side: 'left',
-    }
-  },
+		this._left = 0;
+		this._prevLeft = 0;
+		this._offsetOpen = 0;
+		this._offsetClosed = 0;
+		this._open = false;
+		this._panning = false;
+		this._tweenPending = false;
+		this._lastPress = 0;
+		this._panStartTime = 0;
+		this._syncAfterUpdate = false;
 
-  childContextTypes: {
-    drawer: PropTypes.any
-  },
+		let parallaxDrawerSideNumber = -150;
+		this.statics = {
+			tweenPresets: {
+				parallax: (ratio, side = 'left') => {
+					var drawer = {};
+					drawer[side] = parallaxDrawerSideNumber * (1 - ratio);
+					return { drawer: drawer };
+				}
+			}
+		};
 
-  getChildContext () {
-    return {
-      drawer: this
-    }
-  },
+		this.propsWhomRequireUpdate = [
+			'closedDrawerOffset',
+			'openDrawerOffset',
+			'type'
+		];
 
-  getInitialState () {
-    return { viewport: deviceScreen }
-  },
+		this.state = { viewport: props.deviceScreen }; // getInitialState ()
+	}
 
-  setViewport (e) {
-    var viewport = e.nativeEvent.layout
-    var oldViewport = this.state.viewport
-    if(viewport.width === oldViewport.width && viewport.height === oldViewport.height){
-      return
-    }
-    this.resync(viewport)
-  },
+	getChildContext () {
+		return {
+			drawer: this
+		};
+	}
 
-  resync (viewport, props) {
-    if (viewport) this._syncAfterUpdate = true
-    var viewport = viewport || this.state.viewport
-    var props = props || this.props
-    this._offsetClosed = props.closedDrawerOffset%1 === 0 ? props.closedDrawerOffset : props.closedDrawerOffset * viewport.width
-    this._offsetOpen = props.openDrawerOffset%1 === 0 ? props.openDrawerOffset : props.openDrawerOffset * viewport.width
-    this.setState({ viewport: viewport })
-  },
+	componentWillMount () {
+		this.initialize(this.props);
+	}
 
-  propsWhomRequireUpdate: [
-    'closedDrawerOffset',
-    'openDrawerOffset',
-    'type'
-  ],
+	componentWillReceiveProps (nextProps) {
+		if (this.requiresResync(nextProps)){
+			this.resync(null, nextProps);
+		}
+	}
 
-  requiresResync (nextProps) {
-    for (var i = 0; i < this.propsWhomRequireUpdate.length; i++) {
-      var key = this.propsWhomRequireUpdate[i]
-      if(this.props[key] !== nextProps[key]){ return true }
-    }
-  },
+	componentDidUpdate () {
+		if (this._syncAfterUpdate){
+			this._syncAfterUpdate = false;
+			this._open ? this.open() : this.close();
+		}
+	}
 
-  componentWillReceiveProps (nextProps) {
-    if(this.requiresResync(nextProps)){
-      this.resync(null, nextProps)
-    }
-  },
+	updatePosition () {
+		var mainProps = {};
+		var drawerProps = {};
 
-  initialize (props) {
-    var fullWidth = this.state.viewport.width
-    this._offsetClosed = props.closedDrawerOffset%1 === 0 ? props.closedDrawerOffset : props.closedDrawerOffset*fullWidth
-    this._offsetOpen = props.openDrawerOffset%1 === 0 ? props.openDrawerOffset : props.openDrawerOffset*fullWidth
-    this._prevLeft = this._left
+		var ratio = (this._left - this._offsetClosed) / (this.getOpenLeft() - this._offsetClosed);
 
-    var styles = {
-      container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-      },
-    }
-    styles.main = Object.assign({
-        position: 'absolute',
-        top: 0,
-        height: this.state.viewport.height,
-      }, {borderWidth:0}, this.props.styles.main)
-    styles.drawer = Object.assign({
-        position: 'absolute',
-        top: 0,
-        height: this.state.viewport.height,
-      }, {borderWidth:0}, this.props.styles.drawer)
+		switch (this.props.type) {
+		case 'overlay':
+			drawerProps[this.props.side] = -this.state.viewport.width + this._offsetOpen + this._left;
+			mainProps[this.props.side] = this._offsetClosed;
+			break;
+		case 'static':
+			mainProps[this.props.side] = this._left;
+			drawerProps[this.props.side] = 0;
+			break;
+		case 'displace':
+			mainProps[this.props.side] = this._left;
+			drawerProps[this.props.side] = -this.state.viewport.width + this._left + this._offsetOpen;
+			break;
+		}
 
-    if (props.initializeOpen === true) { // open
-      this._open = true
-      this._left = fullWidth - this._offsetOpen
-      styles.main[this.props.side] = 0
-      styles.drawer[this.props.side] = 0
-      if(props.type === 'static') styles.main[this.props.side] = fullWidth - this._offsetOpen
-      if(props.type === 'displace') styles.main[this.props.side] = fullWidth - this._offsetOpen
-    } else { // closed
-      this._open = false
-      this._left = this._offsetClosed
-      styles.main[this.props.side] = this._offsetClosed
-      if(props.type === 'static') styles.drawer[this.props.side] = 0
-      if(props.type === 'overlay') styles.drawer[this.props.side] = this._offsetClosed + this._offsetOpen - fullWidth
-      if(props.type === 'displace') styles.drawer[this.props.side] = - fullWidth + this._offsetClosed + this._offsetOpen
-    }
+		if (this.props.tweenHandler) {
+			var propsFrag = this.props.tweenHandler(ratio, this.props.side);
+			mainProps = Object.assign(mainProps, propsFrag.main);
+			drawerProps = Object.assign(drawerProps, propsFrag.drawer);
+		}
+		this.drawer.setNativeProps({style: drawerProps});
+		this.main.setNativeProps({style: mainProps});
+	}
 
-    if (this.refs.main) {
-      this.refs.drawer.setNativeProps({ style: {left: styles.drawer.left}})
-      this.refs.main.setNativeProps({ style: {left: styles.main.left}})
-    } else {
-      this.stylesheet = StyleSheet.create(styles)
-      this.responder = PanResponder.create({
-        onStartShouldSetPanResponder: this.handleStartShouldSetPanResponder,
-        onStartShouldSetPanResponderCapture: this.handleStartShouldSetPanResponderCapture,
-        onMoveShouldSetPanResponder: this.handleMoveShouldSetPanResponder,
-        onMoveShouldSetPanResponderCapture: this.handleMoveShouldSetPanResponderCapture,
-        onPanResponderMove: this.handlePanResponderMove,
-        onPanResponderRelease: this.handlePanResponderEnd,
-      })
-    }
+	shouldOpenDrawer (dx) {
+		if (this._open){
+			return dx < this.state.viewport.width * this.props.openDrawerThreshold;
+		}
+		else {
+			return dx > this.state.viewport.width * this.props.openDrawerThreshold;
+		}
+	}
 
-    this.resync(null, props)
-  },
+	handleStartShouldSetPanResponderCapture (e, gestureState) {
+		if (this.props.captureGestures){ return this.handleStartShouldSetPanResponder(e, gestureState); }
+		return false;
+	}
 
-  componentWillMount () {
-    this.initialize(this.props)
-  },
+	handleStartShouldSetPanResponder (e, gestureState) {
+		if (this.props.negotiatePan) {
+			return false;
+		}
+		this._panStartTime = Date.now();
+		if (!this.testPanResponderMask(e, gestureState)){
+			return false;
+		}
+		return true;
+	}
 
-  componentDidUpdate () {
-    if(this._syncAfterUpdate){
-      this._syncAfterUpdate = false
-      this._open ? this.open() : this.close()
-    }
-  },
+	handleMoveShouldSetPanResponderCapture (e, gestureState) {
+		if (this.props.captureGestures && this.props.negotiatePan){
+			return this.handleMoveShouldSetPanResponder(e, gestureState);
+		}
+		return false;
+	}
 
-  updatePosition () {
-    var mainProps = {}
-    var drawerProps = {}
+	handleMoveShouldSetPanResponder (e, gestureState) {
+		if (!this.props.negotiatePan || this.props.disabled){
+			return false;
+		}
+		var swipeToLeft = (gestureState.dx < 0) ? true : false;
+		var swipeToRight = (gestureState.dx > 0) ? true : false;
+		var swipeUpDown = (Math.abs(gestureState.dy) >= Math.abs(gestureState.dx)) ? true : false;
+		var swipeInCloseDirection = (this.props.side === 'left') ? swipeToLeft : swipeToRight;
+		if (swipeUpDown || (this._open && !swipeInCloseDirection) || (!this._open && swipeInCloseDirection)){
+			return false;
+		}
+		return true;
+	}
 
-    var ratio = (this._left-this._offsetClosed) / (this.getOpenLeft()-this._offsetClosed)
+	processTapGestures () {
+		let minLastPressInterval = 500;
+		if (this.props.acceptTap){
+			this._open ? this.close() : this.open();
+		}
+		if (this.props.tapToClose && this._open){
+			this.close();
+		}
+		if (this.props.acceptDoubleTap) {
+			var now = new Date().getTime();
+			if (now - this._lastPress < minLastPressInterval){
+				this._open ? this.close() : this.open();
+			}
+			this._lastPress = now;
+		}
+	}
 
-    switch (this.props.type) {
-      case 'overlay':
-        drawerProps[this.props.side] = -this.state.viewport.width+this._offsetOpen+this._left
-        mainProps[this.props.side] = this._offsetClosed
-        break
-      case 'static':
-        mainProps[this.props.side] = this._left
-        drawerProps[this.props.side] = 0
-        break
-      case 'displace':
-        mainProps[this.props.side] = this._left
-        drawerProps[this.props.side] = -this.state.viewport.width+this._left+this._offsetOpen
-        break
-    }
+	testPanResponderMask (e, gestureState) {
+		if (this.props.disabled){ return false; }
+		var x0 = e.nativeEvent.pageX;
 
-    if (this.props.tweenHandler) {
-      var propsFrag = this.props.tweenHandler(ratio, this.props.side)
-      mainProps = Object.assign(mainProps, propsFrag.main)
-      drawerProps = Object.assign(drawerProps, propsFrag.drawer)
-    }
-    this.refs.drawer.setNativeProps({style: drawerProps})
-    this.refs.main.setNativeProps({style: mainProps})
-  },
+		var deltaOpen = this.props.side === 'left' ? deviceScreen.width - x0 : x0;
+		var deltaClose = this.props.side === 'left' ? x0 : deviceScreen.width - x0;
 
-  shouldOpenDrawer (dx) {
-    if(this._open){
-      return dx < this.state.viewport.width*this.props.openDrawerThreshold
-    }
-    else{
-      return dx > this.state.viewport.width*this.props.openDrawerThreshold
-    }
-  },
+		var whenClosedMask = this.props.panOpenMask % 1 === 0 && this.props.panOpenMask > 1 ? this.props.panOpenMask : deviceScreen.width * this.props.panOpenMask;
+		var whenOpenMask = this.props.panCloseMask % 1 === 0 && this.props.panCloseMask > 1 ? this.props.panCloseMask : deviceScreen.width * this.props.panCloseMask;
+		if ( this._open && deltaOpen > whenOpenMask ){
+			return false;
+		}
+		if ( !this._open && deltaClose > whenClosedMask ){
+			return false;
+		}
+		return true;
+	}
 
-  handleStartShouldSetPanResponderCapture (e, gestureState) {
-    if(this.props.captureGestures) return this.handleStartShouldSetPanResponder(e, gestureState)
-    return false
-  },
+	handlePanResponderMove (e, gestureState) {
+		if (!this.props.acceptPan){
+			return false;
+		}
 
-  handleStartShouldSetPanResponder (e, gestureState) {
-    if (this.props.negotiatePan) return false
-    this._panStartTime = Date.now()
-    if(!this.testPanResponderMask(e, gestureState)){
-      return false
-    }
-    return true
-  },
+		//Math is ugly overly verbose here, probably can be greatly cleaned up
+		var dx = gestureState.dx;
+		//@TODO store adjustedDx max so that it does not uncompensate when panning back
+		var dx = gestureState.dx;
+		//Do nothing if we are panning the wrong way
+		if (this._open ^ dx < 0 ^ this.props.side === 'right'){ return false; }
 
-  handleMoveShouldSetPanResponderCapture (e, gestureState) {
-    if (this.props.captureGestures && this.props.negotiatePan) return this.handleMoveShouldSetPanResponder(e, gestureState)
-    return false
-  },
+		var absDx = Math.abs(dx);
+		var moveX = gestureState.moveX;
+		var relMoveX = this.props.side === 'left'
+			? this._open ? -this.state.viewport.width + moveX : moveX
+			: this._open ? -moveX : this.state.viewport.width - moveX;
+		var delta = relMoveX - dx;
+		var factor = absDx / Math.abs(relMoveX);
+		var adjustedDx = dx + delta * factor;
+		var left = this.props.panStartCompensation ? this._prevLeft + adjustedDx : this._prevLeft + dx;
+		left = Math.min(left, this.getOpenLeft());
+		left = Math.max(left, this.getClosedLeft());
+		this._left = left;
+		this.updatePosition();
+		this._panning = true;
+	}
 
-  handleMoveShouldSetPanResponder (e, gestureState) {
-    if (!this.props.negotiatePan || this.props.disabled) return false
-    var swipeToLeft = (gestureState.dx < 0) ? true : false;
-    var swipeToRight = (gestureState.dx > 0) ? true : false;
-    var swipeUpDown = (Math.abs(gestureState.dy) >= Math.abs(gestureState.dx)) ? true : false;
-    var swipeInCloseDirection = (this.props.side == 'left') ? swipeToLeft: swipeToRight;
-    if(swipeUpDown || (this._open && !swipeInCloseDirection) || (!this._open && swipeInCloseDirection)) return false
-    return true
-  },
+	open () {
+		this.props.onOpenStart && this.props.onOpenStart();
+		tween({
+			start: this._left,
+			end: this.getOpenLeft(),
+			duration: this.props.tweenDuration,
+			easingType: this.props.tweenEasing,
+			onFrame: (tweenValue) => {
+				this._left = tweenValue;
+				this.updatePosition();
+			},
+			onEnd: () => {
+				this._open = true;
+				this._prevLeft = this._left;
+				if (this.props.type === 'overlay'){
+					this.mainOverlay.setNativeProps({ style: { height: this.state.viewport.height }});
+				}
+				this.props.onOpen();
+			}
+		});
+	}
 
-  processTapGestures () {
-    if (this.props.acceptTap) this._open ? this.close() : this.open()
-    if (this.props.tapToClose && this._open) this.close()
-    if (this.props.acceptDoubleTap) {
-      var now = new Date().getTime()
-      if(now - this._lastPress < 500){
-        this._open ? this.close() : this.open()
-      }
-      this._lastPress = now
-    }
-  },
+	close () {
+		this.props.onCloseStart && this.props.onCloseStart();
+		tween({
+			start: this._left,
+			end: this.getClosedLeft(),
+			easingType: this.props.tweenEasing,
+			duration: this.props.tweenDuration,
+			onFrame: (tweenValue) => {
+				this._left = tweenValue;
+				this.updatePosition();
+			},
+			onEnd: () => {
+				this._open = false;
+				this._prevLeft = this._left;
+				if (this.props.type === 'overlay'){
+					this.mainOverlay.setNativeProps({ style: { height: 0 }});
+				}
+				this.props.onClose();
+			}
+		});
+	}
 
-  testPanResponderMask (e, gestureState) {
-    if(this.props.disabled){ return false }
-    var x0 = e.nativeEvent.pageX
+	toggle () {
+		this._open ? this.close() : this.open();
+	}
 
-    var deltaOpen = this.props.side === 'left' ? deviceScreen.width - x0 : x0
-    var deltaClose = this.props.side === 'left' ? x0 : deviceScreen.width - x0
+	handlePanResponderEnd (e, gestureState) {
+		let minDx = 100, minPanStartTime = 500;
+	// @TODO fine tune these thresholds
+		if (gestureState.dx < minDx && (Date.now() - this._panStartTime < minPanStartTime)) {
+			if (!this._open) {
+				this.close();
+			}
+			this._panning = false;
+			this.processTapGestures();
+			return;
+		}
 
-    var whenClosedMask = this.props.panOpenMask % 1 === 0 && this.props.panOpenMask > 1 ? this.props.panOpenMask : deviceScreen.width*this.props.panOpenMask
-    var whenOpenMask = this.props.panCloseMask % 1 === 0 && this.props.panCloseMask > 1 ? this.props.panCloseMask : deviceScreen.width*this.props.panCloseMask
-    if( this._open && deltaOpen > whenOpenMask ) return false
-    if( !this._open && deltaClose > whenClosedMask ) return false
-    return true
-  },
+		var absRelMoveX = this.props.side === 'left'
+			? this._open ? this.state.viewport.width - gestureState.moveX : gestureState.moveX
+			: this._open ? gestureState.moveX : this.state.viewport.width - gestureState.moveX;
+		var calcPos = this.props.relativeDrag ? Math.abs(gestureState.dx) : absRelMoveX;
 
-  handlePanResponderMove (e, gestureState) {
-    if(!this.props.acceptPan){
-      return false
-    }
+		this.shouldOpenDrawer(calcPos) ? this.open() : this.close();
 
-    //Math is ugly overly verbose here, probably can be greatly cleaned up
-    var dx = gestureState.dx
-    //@TODO store adjustedDx max so that it does not uncompensate when panning back
-    var dx = gestureState.dx
-    //Do nothing if we are panning the wrong way
-    if(this._open ^ dx < 0 ^ this.props.side === 'right'){ return false }
+		this.updatePosition();
+		this._prevLeft = this._left;
+		this._panning = false;
+	}
 
-    var absDx = Math.abs(dx)
-    var moveX = gestureState.moveX
-    var relMoveX = this.props.side === 'left'
-      ? this._open ? -this.state.viewport.width + moveX : moveX
-      : this._open ? -moveX : this.state.viewport.width - moveX
-    var delta = relMoveX - dx
-    var factor = absDx/Math.abs(relMoveX)
-    var adjustedDx = dx + delta*factor
-    var left = this.props.panStartCompensation ? this._prevLeft + adjustedDx : this._prevLeft + dx
-    left = Math.min(left, this.getOpenLeft())
-    left = Math.max(left, this.getClosedLeft())
-    this._left = left
-    this.updatePosition()
-    this._panning = true
-  },
+	getMainView () {
+		return (
+			<View
+				{...this.responder.panHandlers}
+				key="main"
+				ref={c => this.main = c}
+				style={[this.stylesheet.main, {width: this.getMainWidth(), height: this.state.viewport.height}]}
+			>
+				{this.props.children}
+				{this.props.type === 'overlay'
+					? <View
+						ref={c => this.mainOverlay = c}
+						style={
+									[this.stylesheet.main, {width: this.getMainWidth(), height: 0, backgroundColor:'transparent'}]
+								}
+							/>
+					: null}
+			</View>
+		);
+	}
 
-  open () {
-    this.props.onOpenStart && this.props.onOpenStart()
-    tween({
-      start: this._left,
-      end: this.getOpenLeft(),
-      duration: this.props.tweenDuration,
-      easingType: this.props.tweenEasing,
-      onFrame: (tweenValue) => {
-        this._left = tweenValue
-        this.updatePosition()
-      },
-      onEnd: () => {
-        this._open = true
-        this._prevLeft = this._left
-        if (this.props.type === 'overlay') this.refs.mainOverlay.setNativeProps({ style: { height: this.state.viewport.height }})
-        this.props.onOpen()
-      }
-    })
-  },
+	getDrawerView () {
+		return (
+			<View
+				{...this.responder.panHandlers}
+				key="drawer"
+				ref={c => this.drawer = c}
+				style={[this.stylesheet.drawer, {width: this.getDrawerWidth(), height: this.state.viewport.height}]}
+			>
+				{this.props.content}
+			</View>
+		);
+	}
 
-  close () {
-    this.props.onCloseStart && this.props.onCloseStart()
-    tween({
-      start: this._left,
-      end: this.getClosedLeft(),
-      easingType: this.props.tweenEasing,
-      duration: this.props.tweenDuration,
-      onFrame: (tweenValue) => {
-        this._left = tweenValue
-        this.updatePosition()
-      },
-      onEnd: () => {
-        this._open = false
-        this._prevLeft = this._left
-        if (this.props.type === 'overlay') this.refs.mainOverlay.setNativeProps({ style: { height: 0 }})
-        this.props.onClose()
-      }
-    })
-  },
+	getOpenLeft () {
+		return this.state.viewport.width - this._offsetOpen;
+	}
 
-  toggle () {
-    this._open ? this.close() : this.open()
-  },
+	getClosedLeft () {
+		return this._offsetClosed;
+	}
 
-  handlePanResponderEnd (e, gestureState) {
-    // @TODO fine tune these thresholds
-    if (gestureState.dx < 100 && (Date.now() - this._panStartTime < 500)) {
-      if (!this._open) this.close()
-      this._panning = false
-      this.processTapGestures()
-      return
-    }
+	getMainWidth () {
+		return this.state.viewport.width - this._offsetClosed;
+	}
 
-    var absRelMoveX = this.props.side === 'left'
-      ? this._open ? this.state.viewport.width - gestureState.moveX : gestureState.moveX
-      : this._open ? gestureState.moveX : this.state.viewport.width - gestureState.moveX
-    var calcPos = this.props.relativeDrag ? Math.abs(gestureState.dx) : absRelMoveX
+	getDrawerWidth () {
+		return this.state.viewport.width - this._offsetOpen;
+	}
 
-    this.shouldOpenDrawer(calcPos) ? this.open() : this.close()
+	initialize (props) {
+		var fullWidth = this.state.viewport.width;
+		this._offsetClosed = props.closedDrawerOffset % 1 === 0 ? props.closedDrawerOffset : props.closedDrawerOffset * fullWidth;
+		this._offsetOpen = props.openDrawerOffset % 1 === 0 ? props.openDrawerOffset : props.openDrawerOffset * fullWidth;
+		this._prevLeft = this._left;
 
-    this.updatePosition()
-    this._prevLeft = this._left
-    this._panning = false
-  },
+		var styles = {
+			container: {
+				flex: 1,
+				justifyContent: 'center',
+				alignItems: 'center',
+			},
+		};
 
-  getMainView () {
-    return (
-      <View
-        key="main"
-        style={[this.stylesheet.main, {width: this.getMainWidth(), height: this.state.viewport.height}]}
-        ref="main"
-        {...this.responder.panHandlers}>
-        {this.props.children}
-        {this.props.type === 'overlay' ? <View ref="mainOverlay" style={[this.stylesheet.main, {width: this.getMainWidth(), height: 0, backgroundColor:'transparent'}]} /> : null}
-      </View>
-    )
-  },
+		styles.main = Object.assign({
+			position: 'absolute',
+			top: 0,
+			height: this.state.viewport.height,
+		}, {borderWidth:0}, this.props.styles.main);
 
-  getDrawerView () {
-    return (
-      <View
-        key="drawer"
-        style={[this.stylesheet.drawer, {width: this.getDrawerWidth(), height: this.state.viewport.height}]}
-        ref="drawer"
-        {...this.responder.panHandlers}>
-        {this.props.content}
-      </View>
-    )
-  },
+		styles.drawer = Object.assign({
+			position: 'absolute',
+			top: 0,
+			height: this.state.viewport.height,
+		}, {borderWidth:0}, this.props.styles.drawer);
 
-  render () {
-    var first = this.props.type === 'overlay' ? this.getMainView() : this.getDrawerView()
-    var second = this.props.type === 'overlay' ? this.getDrawerView() : this.getMainView()
+		if (props.initializeOpen === true) { // open
+			this._open = true;
+			this._left = fullWidth - this._offsetOpen;
+			styles.main[this.props.side] = 0;
+			styles.drawer[this.props.side] = 0;
+			if (props.type === 'static'){ styles.main[this.props.side] = fullWidth - this._offsetOpen; }
+			if (props.type === 'displace') { styles.main[this.props.side] = fullWidth - this._offsetOpen; }
+		} else { // closed
+			this._open = false;
+			this._left = this._offsetClosed;
+			styles.main[this.props.side] = this._offsetClosed;
+			if (props.type === 'static'){ styles.drawer[this.props.side] = 0; }
+			if (props.type === 'overlay'){ styles.drawer[this.props.side] = this._offsetClosed + this._offsetOpen - fullWidth; }
+			if (props.type === 'displace'){ styles.drawer[this.props.side] = - fullWidth + this._offsetClosed + this._offsetOpen; }
+		}
 
-    return (
-      <View style={this.stylesheet.container} key="drawerContainer" onLayout={this.setViewport}>
-        {first}
-        {second}
-      </View>
-    )
-  },
+		if (this.main) {
+			this.drawer.setNativeProps({ style: {left: styles.drawer.left}});
+			this.main.setNativeProps({ style: {left: styles.main.left}});
+		} else {
+			this.stylesheet = StyleSheet.create(styles);
+			this.responder = PanResponder.create({
+				onStartShouldSetPanResponder: this.handleStartShouldSetPanResponder,
+				onStartShouldSetPanResponderCapture: this.handleStartShouldSetPanResponderCapture,
+				onMoveShouldSetPanResponder: this.handleMoveShouldSetPanResponder,
+				onMoveShouldSetPanResponderCapture: this.handleMoveShouldSetPanResponderCapture,
+				onPanResponderMove: this.handlePanResponderMove,
+				onPanResponderRelease: this.handlePanResponderEnd,
+			});
+		}
 
-  getOpenLeft () {
-    return this.state.viewport.width - this._offsetOpen
-  },
+		this.resync(null, props);
+	}
 
-  getClosedLeft () {
-    return this._offsetClosed
-  },
+	handleSetViewport (e) {
+		var viewport = e.nativeEvent.layout;
+		var oldViewport = this.state.viewport;
+		if (viewport.width === oldViewport.width && viewport.height === oldViewport.height){
+			return;
+		}
+		this.resync(viewport);
+	}
 
-  getMainWidth () {
-    return this.state.viewport.width - this._offsetClosed
-  },
+	resync (viewport, props) {
+		if (viewport) {
+			this._syncAfterUpdate = true;
+		}
+		var viewport = viewport || this.state.viewport;
+		var props = props || this.props;
+		this._offsetClosed = props.closedDrawerOffset % 1 === 0 ? props.closedDrawerOffset : props.closedDrawerOffset * viewport.width;
+		this._offsetOpen = props.openDrawerOffset % 1 === 0 ? props.openDrawerOffset : props.openDrawerOffset * viewport.width;
+		this.setState({ viewport: viewport });
+	}
 
-  getDrawerWidth () {
-    return this.state.viewport.width - this._offsetOpen
-  }
+	requiresResync (nextProps) {
+		for (var i = 0; i < this.propsWhomRequireUpdate.length; i++) {
+			var key = this.propsWhomRequireUpdate[i];
+			if (this.props[key] !== nextProps[key]){ return true; }
+		}
+	}
 
-})
+	render() {
+		var first = this.props.type === 'overlay' ? this.getMainView() : this.getDrawerView();
+		var second = this.props.type === 'overlay' ? this.getDrawerView() : this.getMainView();
 
-module.exports = drawer
+		return (
+			<View
+				key="drawerContainer"
+				onLayout={this.handleSetViewport}
+				style={this.stylesheet.container}
+			>
+				{first}
+				{second}
+			</View>
+		);
+	}
+
+}
+
+Drawer.childContextTypes = {
+	drawer: PropTypes.any
+}
+
+Drawer.propTypes = {
+	acceptDoubleTap: React.PropTypes.bool,
+	acceptPan: React.PropTypes.bool,
+	acceptTap: React.PropTypes.bool,
+	captureGestures: React.PropTypes.bool,
+	children: React.PropTypes.node,
+	closedDrawerOffset: React.PropTypes.number,
+	content: React.PropTypes.node,
+	disabled: React.PropTypes.bool,
+	deviceScreen: React.PropTypes.object,
+	initializeOpen: React.PropTypes.bool,
+	negotiatePan: React.PropTypes.bool,
+	onClose: React.PropTypes.func,
+	onCloseStart: React.PropTypes.func,
+	onOpen: React.PropTypes.func,
+	onOpenStart: React.PropTypes.func,
+	openDrawerOffset: React.PropTypes.number,
+	openDrawerThreshold: React.PropTypes.number,
+	panCloseMask: React.PropTypes.number,
+	panOpenMask: React.PropTypes.number,
+	panStartCompensation: React.PropTypes.bool,
+	relativeDrag: React.PropTypes.bool,
+	side: React.PropTypes.oneOf(['left', 'right']),
+	styles: React.PropTypes.object,
+	tapToClose: React.PropTypes.bool,
+	tweenDuration: React.PropTypes.number,
+	tweenEasing: React.PropTypes.string,
+	tweenHandler: React.PropTypes.func,
+	type: React.PropTypes.string,
+}
+
+Drawer.defaultProps = {
+	type: 'displace',
+	closedDrawerOffset: 0,
+	deviceScreen: deviceScreen,
+	openDrawerOffset: 0,
+	openDrawerThreshold: 0.25,
+	relativeDrag: true,
+	panStartCompensation: true,
+	panOpenMask: 0.25,
+	panCloseMask: 0.25,
+	captureGestures: false,
+	negotiatePan: false,
+	initializeOpen: false,
+	tweenHandler: null,
+	tweenDuration: 250,
+	tweenEasing: 'linear',
+	disabled: false,
+	acceptDoubleTap: false,
+	acceptTap: false,
+	acceptPan: true,
+	tapToClose: false,
+	styles: {},
+	onOpen: () => {},
+	onClose: () => {},
+	side: 'left',
+}
+
+module.exports = Drawer;

--- a/package.json
+++ b/package.json
@@ -1,94 +1,39 @@
 {
-  "_args": [
-    [
-      "react-native-drawer",
-      "D:\\Work Space\\Projects\\markalarim_mob"
-    ]
-  ],
-  "_from": "react-native-drawer@latest",
-  "_id": "react-native-drawer@1.13.1",
-  "_inCache": true,
-  "_installable": true,
-  "_location": "/react-native-drawer",
-  "_nodeVersion": "5.1.0",
-  "_npmOperationalInternal": {
-    "host": "packages-5-east.internal.npmjs.com",
-    "tmp": "tmp/react-native-drawer-1.13.1.tgz_1454483244472_0.43950863531790674"
+  "name": "react-native-drawer",
+  "version": "1.13.1",
+  "description": "React Native Drawer",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "_npmUser": {
-    "email": "zstory@ucla.edu",
-    "name": "rt2zz"
-  },
-  "_npmVersion": "3.6.0",
-  "_phantomChildren": {},
-  "_requested": {
-    "name": "react-native-drawer",
-    "raw": "react-native-drawer",
-    "rawSpec": "",
-    "scope": null,
-    "spec": "latest",
-    "type": "tag"
-  },
-  "_requiredBy": [
-    "/"
-  ],
-  "_resolved": "https://registry.npmjs.org/react-native-drawer/-/react-native-drawer-1.13.1.tgz",
-  "_shasum": "4ce8d38bb89c942e4ba2b075f3b6e236e22fe987",
-  "_shrinkwrap": null,
-  "_spec": "react-native-drawer",
-  "_where": "D:\\Work Space\\Projects\\markalarim_mob",
-  "author": {
-    "email": "zack@root-two.com",
-    "name": "rt2zz"
-  },
-  "bugs": {
-    "url": "https://github.com/rt2zz/react-native-drawer/issues"
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:rt2zz/react-native-drawer.git"
   },
   "dependencies": {
     "tween-functions": "^1.0.1"
   },
-  "description": "React Native Drawer",
   "devDependencies": {
-		"babel-eslint": "^4.1.8",
+    "babel-eslint": "^4.1.8",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.16.1",
-    "eslint-plugin-react-native": "^0.5.0"		
-	},
-  "directories": {},
-  "dist": {
-    "shasum": "4ce8d38bb89c942e4ba2b075f3b6e236e22fe987",
-    "tarball": "http://registry.npmjs.org/react-native-drawer/-/react-native-drawer-1.13.1.tgz"
+    "eslint-plugin-react-native": "^0.5.0"
   },
-  "gitHead": "0d05c7ec03dc028f96113d6a3e7fa22b380e611c",
-  "homepage": "https://github.com/rt2zz/react-native-drawer",
   "keywords": [
-    "android",
-    "drawer",
-    "ios",
-    "material design",
-    "menu",
     "react",
-    "react-component",
     "react-native",
-    "side-menu"
+    "react-component",
+    "drawer",
+    "side-menu",
+    "menu",
+    "ios",
+    "android",
+    "material design"
   ],
+  "author": "rt2zz <zack@root-two.com>",
   "license": "MIT",
-  "main": "index.js",
-  "maintainers": [
-    {
-      "name": "rt2zz",
-      "email": "zstory@ucla.edu"
-    }
-  ],
-  "name": "react-native-drawer",
-  "optionalDependencies": {},
-  "readme": "ERROR: No README data found!",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/rt2zz/react-native-drawer.git"
+  "bugs": {
+    "url": "https://github.com/rt2zz/react-native-drawer/issues"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "version": "1.13.1"
+  "homepage": "https://github.com/rt2zz/react-native-drawer"
 }

--- a/package.json
+++ b/package.json
@@ -1,33 +1,94 @@
 {
-  "name": "react-native-drawer",
-  "version": "1.13.1",
-  "description": "React Native Drawer",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "_args": [
+    [
+      "react-native-drawer",
+      "D:\\Work Space\\Projects\\markalarim_mob"
+    ]
+  ],
+  "_from": "react-native-drawer@latest",
+  "_id": "react-native-drawer@1.13.1",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/react-native-drawer",
+  "_nodeVersion": "5.1.0",
+  "_npmOperationalInternal": {
+    "host": "packages-5-east.internal.npmjs.com",
+    "tmp": "tmp/react-native-drawer-1.13.1.tgz_1454483244472_0.43950863531790674"
   },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:rt2zz/react-native-drawer.git"
+  "_npmUser": {
+    "email": "zstory@ucla.edu",
+    "name": "rt2zz"
+  },
+  "_npmVersion": "3.6.0",
+  "_phantomChildren": {},
+  "_requested": {
+    "name": "react-native-drawer",
+    "raw": "react-native-drawer",
+    "rawSpec": "",
+    "scope": null,
+    "spec": "latest",
+    "type": "tag"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/react-native-drawer/-/react-native-drawer-1.13.1.tgz",
+  "_shasum": "4ce8d38bb89c942e4ba2b075f3b6e236e22fe987",
+  "_shrinkwrap": null,
+  "_spec": "react-native-drawer",
+  "_where": "D:\\Work Space\\Projects\\markalarim_mob",
+  "author": {
+    "email": "zack@root-two.com",
+    "name": "rt2zz"
+  },
+  "bugs": {
+    "url": "https://github.com/rt2zz/react-native-drawer/issues"
   },
   "dependencies": {
     "tween-functions": "^1.0.1"
   },
-  "keywords": [
-    "react",
-    "react-native",
-    "react-component",
-    "drawer",
-    "side-menu",
-    "menu",
-    "ios",
-    "android",
-    "material design"
-  ],
-  "author": "rt2zz <zack@root-two.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/rt2zz/react-native-drawer/issues"
+  "description": "React Native Drawer",
+  "devDependencies": {
+		"babel-eslint": "^4.1.8",
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.16.1",
+    "eslint-plugin-react-native": "^0.5.0"		
+	},
+  "directories": {},
+  "dist": {
+    "shasum": "4ce8d38bb89c942e4ba2b075f3b6e236e22fe987",
+    "tarball": "http://registry.npmjs.org/react-native-drawer/-/react-native-drawer-1.13.1.tgz"
   },
-  "homepage": "https://github.com/rt2zz/react-native-drawer"
+  "gitHead": "0d05c7ec03dc028f96113d6a3e7fa22b380e611c",
+  "homepage": "https://github.com/rt2zz/react-native-drawer",
+  "keywords": [
+    "android",
+    "drawer",
+    "ios",
+    "material design",
+    "menu",
+    "react",
+    "react-component",
+    "react-native",
+    "side-menu"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "maintainers": [
+    {
+      "name": "rt2zz",
+      "email": "zstory@ucla.edu"
+    }
+  ],
+  "name": "react-native-drawer",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/rt2zz/react-native-drawer.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "version": "1.13.1"
 }


### PR DESCRIPTION
First of all, thanks. This is really a useful library.

When using Eslint-Plugin-React, the plugin says that `react/no-string-refs: Using this.refs is deprecated.` The description of this rule can be found [here](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md). 

![using-ref](https://cloud.githubusercontent.com/assets/6974198/12874766/979ea662-cde3-11e5-8270-46371eabbb07.png)

Therefore, I started to lint [index.js](https://github.com/root-two/react-native-drawer/blob/master/index.js) and [Tweener.js](https://github.com/root-two/react-native-drawer/blob/master/Tweener.js) files by using [ESLint](http://eslint.org/) and [Eslint-Plugin-React](https://github.com/yannickcr/eslint-plugin-react).

And now, I finished the linting and converting to an ES6 class.

Some information;
- I can use this plugin on an Android emulator on Windows. But this code **_never tested completely for Android and espically iOS**_.
- `index.js` and `Tweener.js` have been linted.
- The drawer component -that is within the index.js file- has been refocatored as an ES6 class. Removed 'this.ref' usages.
- Added Android example file.
- `SliderIOS` components changed with `react-native-slider` components and `SwitchIOS` components changed with `Switch` components. Because of the shortage of an iOS, **they have not been tested on any iOS emulator**.
