### PR TITLE
Add device orientation support

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ var Orientation = require('react-native-orientation')
 
 Orientation.getOrientation((err,orientation)=> {
   console.log("Current Device Orientation: ", orientation);
-  if(orientation == 'LANDSCAPE') {
+  if(orientation == 'LANDSCAPE' && (deviceScreen.height > deviceScreen.width)) {
+    deviceScreen = flipDevice(deviceScreen);
+  }
+  if(orientation == 'PORTRAIT' && (deviceScreen.height < deviceScreen.width)) {
     deviceScreen = flipDevice(deviceScreen);
   }
 });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,21 @@ var React = require('react-native')
 var { PanResponder, View, StyleSheet, Dimensions, PropTypes } = React
 var deviceScreen = Dimensions.get('window')
 var tween = require('./Tweener')
+var Orientation = require('react-native-orientation')
+
+Orientation.getOrientation((err,orientation)=> {
+  console.log("Current Device Orientation: ", orientation);
+  if(orientation == 'LANDSCAPE') {
+    deviceScreen = flipDevice(deviceScreen);
+  }
+});
+
+function flipDevice(deviceScreen) {
+  var temp = deviceScreen.width;
+  deviceScreen.width = deviceScreen.height;
+  deviceScreen.height = temp;
+  return deviceScreen;
+}
 
 var drawer = React.createClass({
 
@@ -193,6 +208,18 @@ var drawer = React.createClass({
 
   componentWillMount () {
     this.initialize(this.props)
+  },
+
+  componentDidMount () {
+    Orientation.addOrientationListener(this._orientationDidChange);
+  },
+
+  componentWillUnmount () {
+    Orientation.removeOrientationListener(this._orientationDidChange);
+  },
+
+  _orientationDidChange (orientation) {
+    deviceScreen = flipDevice(deviceScreen);
   },
 
   componentDidUpdate () {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "git@github.com:rt2zz/react-native-drawer.git"
   },
   "dependencies": {
-    "tween-functions": "^1.0.1"
+    "tween-functions": "^1.0.1",
+    "react-native-orientation": "^1.13.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
panOpenMask and panCloseMask sometimes do not respond correctly to device orientation changes. If you rotate the device from portrait to landscape, the right side of the screen becomes un-clickable because the mask now thinks the device landscape width is the portrait width.

In React Native 0.19, the behavior or Dimensions.get('window') appear to have changed, so that the width and height _sometimes_ correctly refer to device width and height. So, if you start the app in portrait or landscape but don't change orientations once the app has started, the behavior of the app is _sometimes_ correct.

This fix uses react-native-orientation to detect and respond to device orientation changes. It also "checks" the output of Dimensions.get('window') to make sure deviceScreen is initialized correctly.

The downside of this PR is that react-native-orientation is not pure javascript, so you will need to drag additional files into XCode/etc. It does have Android support.
