### PR TITLE
restore height prop to main view

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,7 +368,7 @@ class Drawer extends Component {
         {...this.responder.panHandlers}
         key="main"
         ref={c => this.main = c}
-        style={[this.stylesheet.main, {width: this.getMainWidth()}]}
+        style={[this.stylesheet.main, {width: this.getMainWidth(), height: this.state.viewport.height}]}
         >
         {this.props.children}
         {this.props.type === 'overlay'


### PR DESCRIPTION
Wondering why this was omitted when Drawer View has it. This fixes our Android build. 
