### PR TITLE
Fixes #83

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,11 +476,12 @@ class Drawer extends Component {
     let viewport = e.nativeEvent.layout
     let oldViewport = this.state.viewport
     if (viewport.width === oldViewport.width && viewport.height === oldViewport.height) return
-    this.resync(viewport)
+    let didRotationChange = viewport.width !== oldViewport.width
+    this.resync(viewport, null, didRotationChange)
   }
 
-  resync(viewport, props) {
-    if (viewport) this._syncAfterUpdate = true
+  resync(viewport, props, didRotationChange) {
+    if (didRotationChange) this._syncAfterUpdate = true
     viewport = viewport || this.state.viewport
     props = props || this.props
     this._offsetClosed = props.closedDrawerOffset % 1 === 0 ? props.closedDrawerOffset : props.closedDrawerOffset * viewport.width


### PR DESCRIPTION
The purpose of `resync` method is to set `_syncAfterUpdate` flag to true when new viewport is passed, so that we can either close/open menu on landscape change to avoid glitches (mainly when entering portrait mode since we may lose the content view completely)

However, that prevents menu from being opened/closed when any other view (or system) is modyfing the **height** only. That can be either green bar mentioned in #83 when active call or the blue one indicating wifi hotspot - it's a part of statusBar, so when you start hiding it in the onStart callback, the height change will be propagated to the drawer before the _isOpen property is set (which results in menu going back to its previous position)

Since the purpose of the method is to fix potential glitch caused by width change, we ignore height changes.

Tested on actual device, works like a charm.
