### PR TITLE
add open props

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ This module supports a wide range of drawer styles, and hence has *a lot* of pro
 - `openDrawerThreshold` (Number) `.25` - Ratio of screen width that must be travelled to trigger a drawer open/close
 - `panOpenMask` (Number) `.05` - Ratio of screen width that is valid for the start of a pan open action.
 - `panCloseMask` (Number) `.25` - Ratio of screen width that is valid for the start of a pan close action.
-- `initializeOpen` (Boolean) `false` - Initialize with drawer open?
+- `initializeOpen` (Boolean) `false` - Initialize with drawer open? [DEPRECATED]
+- `open` (Boolean) `false` - Initialize with drawer open?
 - `side` (String left|right) `left` - which side the drawer should be on.
 
 ##### Experimental & Deprecated Props

--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ class Drawer extends Component {
     content: React.PropTypes.node,
     deviceScreen: React.PropTypes.object,
     disabled: React.PropTypes.bool,
+    open: React.PropTypes.bool,
+    // TODO remove 'initializeOpen' after version bump
     initializeOpen: React.PropTypes.bool,
     negotiatePan: React.PropTypes.bool,
     onClose: React.PropTypes.func,
@@ -74,6 +76,7 @@ class Drawer extends Component {
     panCloseMask: 0.25,
     captureGestures: false,
     negotiatePan: false,
+    open: false,
     initializeOpen: false,
     tweenHandler: null,
     tweenDuration: 250,
@@ -139,6 +142,13 @@ class Drawer extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.requiresResync(nextProps)) {
       this.resync(null, nextProps)
+    }
+    if (this.props.open !== nextProps.open) {
+      if (nextProps.open === true && !this._open) {
+        this.open();
+      } else if (nextProps.open === false && this._open) {
+        this.close();
+      }
     }
   }
 
@@ -440,7 +450,7 @@ class Drawer extends Component {
       top: 0,
     }, {borderWidth:0}, this.props.styles.drawer)
 
-    if (props.initializeOpen === true) { // open
+    if (props.open === true || props.initializeOpen === true) { // open
       this._open = true
       this._left = fullWidth - this._offsetOpen
       styles.main[this.props.side] = 0


### PR DESCRIPTION
Added support to handle if drawer is open or closed through props

I need this so I can control if drawer is open from anywhere in the app using flux, no need to pass this.drawer reference
