### PR TITLE
Use mainOverlay instead of mainOverlayProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ class Drawer extends Component {
       let propsFrag = this.props.tweenHandler(ratio, this.props.side)
       mainProps = Object.assign(mainProps, propsFrag.main)
       drawerProps = Object.assign(drawerProps, propsFrag.drawer)
-      mainOverlayProps = propsFrag.mainOverlayProps
+      mainOverlayProps = propsFrag.mainOverlay
     }
     this.drawer.setNativeProps({style: drawerProps})
     this.main.setNativeProps({style: mainProps})


### PR DESCRIPTION
From the README:

`tweenHandler` (Function) `null` - Takes in the pan ratio (decimal 0 to 1) that represents the tween percent. Returns and object of native props to be set on the constituent views { drawer: {/_native props_/}, main: {/_native props_/}, mainOverlay: {/_native props_/} }
