### PR TITLE
Added ; to resolve runtime error

### DIFF
--- a/index.js
+++ b/index.js
@@ -468,11 +468,11 @@ export default class Drawer extends Component {
   };
 
   /*** DYNAMIC GETTERS ***/
-  getOpenLeft = () => this.state.viewport.width - this._offsetOpen
-  getClosedLeft = () => this._offsetClosed
-  getHeight = () => this.state.viewport.height
-  getMainWidth = () => this.state.viewport.width - this._offsetClosed
-  getDrawerWidth = () => this.state.viewport.width - this._offsetOpen
+  getOpenLeft = () => this.state.viewport.width - this._offsetOpen;
+  getClosedLeft = () => this._offsetClosed;
+  getHeight = () => this.state.viewport.height;
+  getMainWidth = () => this.state.viewport.width - this._offsetClosed;
+  getDrawerWidth = () => this.state.viewport.width - this._offsetOpen;
   getOpenMask = () => {
     let panCloseMask = this.props.panCloseMask === null ? Math.max(0.05, this._offsetOpen) : this.props.panCloseMask
     return panCloseMask % 1 === 0 ? panCloseMask : this.state.viewport.width * panCloseMask


### PR DESCRIPTION
Without these semicolons, I was experiencing the red screen of death when trying to run with 2.1.0

FWIW... I'm using RN 0.21.0 and node 5.x / npm 3.x

<img width="375" alt="screen shot 2016-05-01 at 4 56 58 pm" src="https://cloud.githubusercontent.com/assets/10797610/14944620/10480722-0fbe-11e6-8010-f06176f62f49.png">
