### PR TITLE
Catch null this.main and this.drawer in updatePosition

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,10 +228,12 @@ export default class Drawer extends Component {
       mainOverlayProps = propsFrag.mainOverlay
       drawerOverlayProps = propsFrag.drawerOverlay
     }
-    this.drawer.setNativeProps({style: drawerProps})
-    this.main.setNativeProps({style: mainProps})
-    if (mainOverlayProps) this.mainOverlay.setNativeProps({style: mainOverlayProps})
-    if (drawerOverlayProps) this.drawerOverlay.setNativeProps({style: drawerOverlayProps})
+    if (this.main && mainOverlayProps && drawerOverlayProps) {
+      this.drawer.setNativeProps({style: drawerProps})
+      this.main.setNativeProps({style: mainProps})
+      this.mainOverlay.setNativeProps({style: mainOverlayProps})
+      this.drawerOverlay.setNativeProps({style: drawerOverlayProps})
+    }
   };
 
   shouldOpenDrawer(dx) {


### PR DESCRIPTION
On some calls to updatePosition this.drawer and this.main were null. This occurred on Android API Level 22 but not on 23 or earlier.
