### PR TITLE
Catch nulls in updatePosition and adjustForCaptureGestures

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,10 +228,12 @@ export default class Drawer extends Component {
       mainOverlayProps = propsFrag.mainOverlay
       drawerOverlayProps = propsFrag.drawerOverlay
     }
-    this.drawer.setNativeProps({style: drawerProps})
-    this.main.setNativeProps({style: mainProps})
-    if (mainOverlayProps) this.mainOverlay.setNativeProps({style: mainOverlayProps})
-    if (drawerOverlayProps) this.drawerOverlay.setNativeProps({style: drawerOverlayProps})
+    if (this.main && this.drawer && this.mainOverlay && this.drawerOverlay) {
+      this.drawer.setNativeProps({style: drawerProps})
+      this.main.setNativeProps({style: mainProps})
+      if (mainOverlayProps) this.mainOverlay.setNativeProps({style: mainOverlayProps})
+      if (drawerOverlayProps) this.drawerOverlay.setNativeProps({style: drawerOverlayProps})
+    }
   };
 
   shouldOpenDrawer(dx) {
@@ -426,8 +428,10 @@ export default class Drawer extends Component {
   adjustForCaptureGestures() {
     if (!this.props.captureGestures) return
     let shouldCapture = this.shouldCaptureGestures()
-    this.mainOverlay.setNativeProps({ pointerEvents: shouldCapture && this._open ? 'auto' : 'none' })
-    this.drawerOverlay.setNativeProps({ pointerEvents: shouldCapture && !this._open ? 'auto' : 'none' })
+    if (this.mainOverlay && this.drawerOverlay) {
+      this.mainOverlay.setNativeProps({ pointerEvents: shouldCapture && this._open ? 'auto' : 'none' })
+      this.drawerOverlay.setNativeProps({ pointerEvents: shouldCapture && !this._open ? 'auto' : 'none' })
+    }
   }
 
   setInteractionHandle() {


### PR DESCRIPTION
On some calls to updatePosition this.drawer and this.main were null and
to adjustForCaptureGestures this.mainOverlay and this.drawerOverlay
were null.
This occurred on Android API Level 22 but not on 23 or earlier.

Signed-off-by: Ian Hilt ian@novacreative.com
