### PR TITLE
Fixes problem where this._panning can get into a state where it never gets unset

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,6 +283,7 @@ export default class Drawer extends Component {
   };
 
   onPanResponderRelease = (e, gestureState) => {
+    this._panning = false;
     if (gestureState.moveX < 125) this.processTapGestures()
     if (Math.abs(gestureState.dx) < 50 && this._activeTween) return
 
@@ -290,7 +291,6 @@ export default class Drawer extends Component {
 
     this.updatePosition()
     this._prevLeft = this._left
-    this._panning = false
   };
 
   processShouldSet = (e, gestureState) => {


### PR DESCRIPTION
**The Problem**

In certain situations `this._panning` never resets to false after a pan is released. This happens when the drawer is open (for my case, it was a right drawer), and the user pans to close but releases it early (< 125 dX). This triggers the tapToClose, which calls `close()`, which sets the active tween, which returns early from the pan release method. When that happens, the drawer closes, but no new pans will be recognized, because `this._panning` is still true, despite being released.

**The Fix**

I just moved the `this._panning = false` above the returns since when this `onPanResponderRelease` is called, technically we're done panning.
