### PR TITLE
Fix open or close drawer when gesture should be cancelled

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,7 @@ export default class Drawer extends Component {
         onMoveShouldSetPanResponderCapture: this.onMoveShouldSetPanResponderCapture,
         onPanResponderMove: this.onPanResponderMove,
         onPanResponderRelease: this.onPanResponderRelease,
+	onPanResponderTerminate: this.onPanResponderTerminate
       })
     }
 
@@ -239,6 +240,10 @@ export default class Drawer extends Component {
     else return this._open ^ Math.abs(dx) > this.state.viewport.width * this.props.panThreshold
   }
 
+  onPanResponderTerminate = (e, gestureState) => {
+    this.shouldOpenDrawer(gestureState.dx) ? this.open() : this.close()
+  };
+    
   onStartShouldSetPanResponderCapture = (e, gestureState) => {
     if (this.shouldCaptureGestures()) return this.processShouldSet(e, gestureState)
     return false

--- a/index.js
+++ b/index.js
@@ -241,6 +241,7 @@ export default class Drawer extends Component {
   }
 
   onPanResponderTerminate = (e, gestureState) => {
+    this._panning = false
     this.shouldOpenDrawer(gestureState.dx) ? this.open() : this.close()
   };
     


### PR DESCRIPTION
According to https://facebook.github.io/react-native/docs/panresponder.html, onPanResponderTerminate should be used to cancel an active pan.

Currently, when we use something like a scrollview as side menu, when we start swiping we can break it by touching the scrollview inside the menu which can be focused because there is no state changing and then pointerEvents is still set to "auto".
