### PR TITLE
adds callback to open() and close()

### DIFF
--- a/index.js
+++ b/index.js
@@ -395,11 +395,9 @@ export default class Drawer extends Component {
         this.props.onOpen()
         this.clearInteractionHandle()
 
-         if(typeof(type) == 'function') {
-            type(); // this is actually a callback
-          } else if(typeof(cb) == 'function') {
-            cb();
-          }
+        if(typeof type === 'function') {
+          type() // this is actually a callback
+        } else cb && cb()
         
       }
     })
@@ -431,11 +429,9 @@ export default class Drawer extends Component {
         this.props.onClose()
         this.clearInteractionHandle()
 
-        if(typeof(type) == 'function') {
-          type(); // this is actually a callback
-        } else if(typeof(cb) == 'function') {
-          cb();
-        }
+        if(typeof type === 'function') {
+          type() // this is actually a callback
+        } else cb && cb()
 
       }
     })

--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@ export default class Drawer extends Component {
     }
   };
 
-  open = (type) => {
+  open = (type, cb) => {
     let start = this._left
     let end = this.getOpenLeft()
 
@@ -394,11 +394,18 @@ export default class Drawer extends Component {
         this.adjustForCaptureGestures()
         this.props.onOpen()
         this.clearInteractionHandle()
+
+         if(typeof(type) == 'function') {
+            type(); // this is actually a callback
+          } else if(typeof(cb) == 'function') {
+            cb();
+          }
+        
       }
     })
   };
 
-  close = (type) => {
+  close = (type, cb) => {
     let start = this._left
     let end = this.getClosedLeft()
 
@@ -423,6 +430,13 @@ export default class Drawer extends Component {
         this.adjustForCaptureGestures()
         this.props.onClose()
         this.clearInteractionHandle()
+
+        if(typeof(type) == 'function') {
+          type(); // this is actually a callback
+        } else if(typeof(cb) == 'function') {
+          cb();
+        }
+
       }
     })
   };


### PR DESCRIPTION
Useful for when you want to pass a callback on the fly

```
Refs.Drawer.close(() => {
    Refs.Navigator.push({name: 'SpecificRoute'});
});
```

can still use `type` param

```
Refs.Drawer.close('force', () => {
    Refs.Navigator.push({name: 'SpecificRoute'});
});
```
