### PR TITLE
Apply a dark "scrim" when drawer is open

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ class Application extends Component {
 </Drawer>
 
 const drawerStyles = {
-  drawer: { shadowColor: '#000000', shadowOpacity: 0.8, shadowRadius: 3},
-  main: {paddingLeft: 3},
+  drawer: { shadowColor: '#000000', shadowOpacity: 0.8, shadowRadius: 3 },
+  main: { paddingLeft: 3 },
+  mainScrim: { backgroundColor: 'rgba(0, 0, 0, 0.6)' },
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -537,7 +537,11 @@ export default class Drawer extends Component {
         <View
           pointerEvents={ this._open && this.shouldCaptureGestures() ? 'auto' : 'none' }
           ref={c => this.mainOverlay = c}
-          style={[styles.overlay, this.props.styles && this.props.styles.mainOverlay]}
+          style={[
+            styles.overlay,
+            this.props.styles && this.props.styles.mainOverlay,
+            this._open && this.props.styles && this.props.styles.mainScrim
+          ]}
           />
       </View>
     )


### PR DESCRIPTION
When used as suggested in the example docs, this adds a dark shadow over the main content when the drawer is open. Using a scrim is suggested in Google's [Material Design guide](https://material.google.com/style/imagery.html#imagery-ui-integration), and is done in many popular apps.

It would be awesome if we could animate this, but I also don't want to bog anything down performance-wise. It would be simple to add a new state item e.g. `openRatio`, and apply the scrim incrementally based on how far open the drawer is. Just let me know if you'd prefer that I implement this!
