### PR TITLE
Fixed open and closed offset in accepting decimal values

### DIFF
--- a/index.js
+++ b/index.js
@@ -501,11 +501,11 @@ export default class Drawer extends Component {
   };
   getOpenOffset = (props, viewport) => {
     if (typeof props.openDrawerOffset === 'function') return props.openDrawerOffset(viewport)
-    return props.openDrawerOffset % 1 === 0 ? props.openDrawerOffset : props.openDrawerOffset * viewport.width
+    return props.openDrawerOffset > 1 || props.openDrawerOffset < 0 ? props.openDrawerOffset : props.openDrawerOffset * viewport.width
   };
   getClosedOffset = (props, viewport) => {
     if (typeof props.closedDrawerOffset === 'function') return props.closedDrawerOffset(viewport)
-    return props.closedDrawerOffset % 1 === 0 ? props.closedDrawerOffset : props.closedDrawerOffset * viewport.width
+    return props.closedDrawerOffset > 1 || props.closedDrawerOffset < 0 ? props.closedDrawerOffset : props.closedDrawerOffset * viewport.width
   };
   /*** END DYNAMIC GETTERS ***/
 


### PR DESCRIPTION
Using decimal values for closedOffset and openOffset didn't work before, and it is sometimes useful to programatically calculate the size of the drawer (without doing Math.round unnecessarily). 