### PR TITLE
correction example material drawer should have panOpenMask props

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ class Application extends Component {
   content={<ControlPanel />}
   tapToClose={true}
   openDrawerOffset={0.2} // 20% gap on the right side of drawer
+  panOpenMask={0.2}
   panCloseMask={0.2}
   closedDrawerOffset={-3}
   styles={drawerStyles}
@@ -179,3 +180,5 @@ Component was adapted from and inspired by
 [@khanghoang](https://github.com/khanghoang)'s [RNSideMenu](https://github.com/khanghoang/RNSideMenu)
 *AND*
 [@kureevalexey](https://twitter.com/kureevalexey)'s [react-native-side-menu](https://github.com/Kureev/react-native-side-menu)
+
+


### PR DESCRIPTION
After following the examples, I was unable to slide from side screen, I realize that I must give props panOpenMask to Drawer at least with {0.1} value