### PR TITLE
resync called on the next tick when orientation changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -464,7 +464,7 @@ export default class Drawer extends Component {
     let oldViewport = this.state.viewport
     if (viewport.width === oldViewport.width && viewport.height === oldViewport.height) return
     let didRotationChange = viewport.width !== oldViewport.width
-    this.resync(viewport, null, didRotationChange)
+    setTimeout(this.resync.bind(this, viewport, null, didRotationChange));
   };
 
   resync = (viewport, props, didRotationChange) => {


### PR DESCRIPTION
related to [issue #261](https://github.com/root-two/react-native-drawer/issues/261) and many others

When the user changes the orientation very often while the drawer is open the onLayout callback is called before componentWillReceiveProps and the offset calculations are wrong. The bug is fixed by calling resync method on the next tick in the onLayout callback.
