### PR TITLE
Add ability to pan on the drawer view when it is 'open'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ export default class Drawer extends Component {
     acceptDoubleTap: PropTypes.bool,
     acceptPan: PropTypes.bool,
     acceptTap: PropTypes.bool,
+    acceptPanOnDrawer: PropTypes.bool,
     captureGestures: PropTypes.oneOf([true, false, 'open', 'closed']),
     children: PropTypes.node,
     closedDrawerOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
@@ -90,6 +91,7 @@ export default class Drawer extends Component {
     acceptDoubleTap: false,
     acceptTap: false,
     acceptPan: true,
+    acceptPanOnDrawer: true,
     tapToClose: false,
 
     styles: {},
@@ -304,7 +306,7 @@ export default class Drawer extends Component {
 
   processMoveShouldSet = (e, gestureState) => {
     let inMask = this.testPanResponderMask(e, gestureState)
-    if (!inMask) return false
+    if (!inMask && !this.props.acceptPanOnDrawer) return false
     if (!this.props.acceptPan) return false
 
     if (!this.props.negotiatePan || this.props.disabled || !this.props.acceptPan || this._panning) return false

--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ export default class Drawer extends Component {
 
   processMoveShouldSet = (e, gestureState) => {
     let inMask = this.testPanResponderMask(e, gestureState)
-    if (!inMask && !this.props.acceptPanOnDrawer) return false
+    if (!inMask && (!this.props.acceptPanOnDrawer || this._open === false )) return false
     if (!this.props.acceptPan) return false
 
     if (!this.props.negotiatePan || this.props.disabled || !this.props.acceptPan || this._panning) return false


### PR DESCRIPTION
**Purpose**
I want to swipe on the side menu (in this case DrawerContent) to close the drawer. 

So I play around with the original source code and configure as below:

```javascript
<Drawer
  type="static"
  content={<DrawerContent />}
  openDrawerOffset={100}
  styles={drawerStyles}
  tweenHandler={Drawer.tweenPresets.parallax}
  tapToClose={true}
  openDrawerOffset={0.2}
  panCloseMask={0.99} // There is a bug here when set 1.0. Set this to expand the mask so that be able to pan on DrawerContent
  panOpenMask={0.2}
  >
    <Main />
</Drawer>
```

Now I can pan on the DrawerContent to close the Drawer.
The problem is, if there is any clickable views in DrawerContent, it will be ignored when clicking on it.
So I added this props to prioritize the subviews gesture responder.

```javascript
captureGestures={false}
```

Now I can click on the subviews in DrawerContent.
But the problem now is, because Drawer does not capture gestures, clicking on subviews in Main is captured. I don't want those. 
What I want is when clicking on Main, Drawer will be closed instead of propagating the gesture to the subviews.
This problem does not happen when using ```captureGestures={'open'}```

**So**
I think if there is some code for Drawer to capture gestures when clicking/panning on Main to close the Drawer. And not capturing gestures when clicking on DrawerContent so that subviews (ex. side menu items) be able to click.

Actually the original code base already did that with the configuration below
```javascript
<Drawer
  type="static"
  content={<DrawerContent />}
  openDrawerOffset={100}
  styles={drawerStyles}
  tweenHandler={Drawer.tweenPresets.parallax}
  tapToClose={true}
  openDrawerOffset={0.2}
  panCloseMask={0.2} // There is a bug here when set 1.0. Set this to expand the mask so that be able to pan on DrawerContent
  panOpenMask={0.2}
  negotiatePan={true}
  >
    <Main />
</Drawer>
```

**However**
The original code limits gestures when panning outside the mask. That's why I can not pan on the DrawerContent.

**Finally**
I edit some lines of code to allow panning in the DrawerContent when setting ```acceptPanOnDrawer={true}``` (default=true).