### PR TITLE
fix to work with React 16.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { PanResponder, View, StyleSheet, Dimensions, InteractionManager, I18nManager } from 'react-native'
 
 import tween from './tweener'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "git@github.com:rt2zz/react-native-drawer.git"
   },
   "dependencies": {
-    "tween-functions": "^1.0.1"
+    "tween-functions": "^1.0.1",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.8",


### PR DESCRIPTION
Changed PropTypes it use the correct package `import PropTypes from 'prop-types';`
Works with React 16.0